### PR TITLE
Add timestamps in recordings.

### DIFF
--- a/packages/grabette/grabette/hardware/camera.py
+++ b/packages/grabette/grabette/hardware/camera.py
@@ -113,6 +113,7 @@ class VideoCapture:
         self._first_sensor_ts = None
         self._sync_offset_ms = 0.0
         self._frame_count = 0
+        self._picam2.pre_callback = self._on_frame
 
         self._recording = True
         gc.disable()  # Prevent GC pauses from dropping frames during recording


### PR DESCRIPTION
Timestamps was empty in the recordings. 
Now, picamera2 invokes pre-callback in the camera thread for every request : _on_frame records the per-frame timestamp.