### PR TITLE
Modify depth frame capture in mkv format.

### DIFF
--- a/packages/grabette-postprocess/scripts/rgbd_slam/convert_episode_to_oak.py
+++ b/packages/grabette-postprocess/scripts/rgbd_slam/convert_episode_to_oak.py
@@ -50,6 +50,22 @@ def _extract_mp4_frames(mp4_path: Path, out_dir: Path) -> int:
     subprocess.run(cmd, check=True)
     return len(list(out_dir.glob("*.png")))
 
+def _extract_depth_video(mkv_path: Path, out_dir: Path) -> int:
+    """Decode a lossless 16-bit depth video (FFV1 gray16le) to uint16 PNGs
+    (000000.png…). Frame i is the i-th depth frame in encode order, which the
+    packer (grabette.hf) writes in oakd_depth_timestamps.json order. No
+    -pix_fmt on output: ffmpeg writes native 16-bit PNG, preserving the mm
+    values exactly (verified bit-identical to the source PNGs)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-i", str(mkv_path),
+        "-start_number", "0",
+        str(out_dir / "%06d.png"),
+    ]
+    subprocess.run(cmd, check=True)
+    return len(list(out_dir.glob("*.png")))
+
 
 def convert_episode(ep_dir: Path, force: bool = False) -> Path:
     oak_dir = ep_dir / "oak"
@@ -60,15 +76,25 @@ def convert_episode(ep_dir: Path, force: bool = False) -> Path:
         shutil.rmtree(oak_dir)
 
     # --- Required inputs ---
+    # Depth comes either as a compact lossless video (oakd_depth.mkv, the format
+    # the uploader now produces) or, for older recordings, a directory of
+    # per-frame PNGs (oakd_depth/). Either is accepted.
+    left_mp4 = ep_dir / "oakd_left.mp4"
+    depth_dir = ep_dir / "oakd_depth"
+    depth_mkv = ep_dir / "oakd_depth.mkv"
     left_mp4 = ep_dir / "oakd_left.mp4"
     depth_src = ep_dir / "oakd_depth"
     left_ts_json = ep_dir / "oakd_left_timestamps.json"
     depth_ts_json = ep_dir / "oakd_depth_timestamps.json"
     imu_json = ep_dir / "oakd_imu.json"
     calib_src = ep_dir / "oakd_calib_offline.json"
-    for p in (left_mp4, depth_src, left_ts_json, depth_ts_json, imu_json, calib_src):
+    for p in (left_mp4, left_ts_json, depth_ts_json, imu_json, calib_src):
         if not p.exists():
             raise FileNotFoundError(f"Missing required input: {p}")
+
+    if not depth_mkv.is_file() and not depth_dir.is_dir():
+        raise FileNotFoundError(
+            f"Missing depth: neither {depth_mkv} nor {depth_dir}")
 
     oak_dir.mkdir(parents=True)
     (oak_dir / "frames").mkdir()
@@ -106,11 +132,27 @@ def convert_episode(ep_dir: Path, force: bool = False) -> Path:
             shutil.move(str(tmp_frames / f"{idx:06d}.png"),
                         str(oak_dir / "frames" / f"{idx:06d}.png"))
 
-        # Copy depth PNGs (named by seq) → oak/depth/<idx>.png
+        # Resolve each depth seq to a source PNG. For the video format, decode
+        # it once to temp PNGs; frame i ↔ depth_ts[i].seq (encode order). For
+        # the legacy dir format, the PNG is named by seq.
+        if depth_mkv.is_file():
+            tmp_depth = Path(tmp) / "depth"
+            _extract_depth_video(depth_mkv, tmp_depth)
+            seq_to_png = {
+                int(s["seq"]): tmp_depth / f"{i:06d}.png"
+                for i, s in enumerate(depth_ts)
+            }
+        else:
+            seq_to_png = {
+                int(s["seq"]): depth_dir / f'{int(s["seq"]):08d}.png'
+                for s in depth_ts
+            }
+
+        # Copy matched depth frames → oak/depth/<idx>.png
         for idx, (seq, _) in enumerate(matched[:n]):
-            depth_png = depth_src / f"{seq:08d}.png"
-            if not depth_png.exists():
-                raise FileNotFoundError(f"depth PNG missing for seq {seq}: {depth_png}")
+            depth_png = seq_to_png.get(seq)
+            if depth_png is None or not depth_png.exists():
+                raise FileNotFoundError(f"depth frame missing for seq {seq}")
             shutil.copyfile(depth_png, oak_dir / "depth" / f"{idx:06d}.png")
 
         # --- Write timestamps.csv (idx, ns) ---

--- a/packages/grabette/grabette/hardware/oakd.py
+++ b/packages/grabette/grabette/hardware/oakd.py
@@ -35,6 +35,7 @@ import json
 import logging
 import shutil
 import subprocess
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -443,6 +444,9 @@ class OakdCapture:
             (self._output_dir / "oakd_clock_pairs.json").write_text(
                 json.dumps({"pairs": self._clock_pairs})
             )
+            # Pack depth PNGs → one lossless video (after its timestamps sidecar
+            # is written), same finalization stage as the H.264 mux above.
+            self._pack_depth_video()
 
         stats = {
             "left_frames": len(self._left_ts),
@@ -705,6 +709,52 @@ class OakdCapture:
             pass
         if result.returncode != 0:
             logger.error("ffmpeg muxing failed for %s: %s", name, result.stderr[-300:])
+
+    def _pack_depth_video(self) -> None:
+        """Finalize depth: encode oakd_depth/*.png → one lossless FFV1 16-bit
+        video (oakd_depth.mkv) in capture (= depth_ts) order, then drop the PNG
+        dir. Mirrors the H.264→mp4 mux above: one file per episode instead of
+        ~600 PNGs, ~2× smaller, and bit-identical once decoded — so the offline
+        SLAM input is unchanged. Best-effort: on any failure the PNGs are kept
+        and used as-is (convert/episode_check accept either layout)."""
+        if not self.enable_depth or not self._output_dir:
+            return
+        depth_dir = self._output_dir / "oakd_depth"
+        if not depth_dir.is_dir() or not self._depth_ts:
+            return
+        out = self._output_dir / "oakd_depth.mkv"
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                stage = Path(tmp)
+                # Symlink (not copy) the PNGs under sequential names in capture
+                # order, so the offline convert can map video frame i back to
+                # depth_ts[i].seq. Symlinks keep staging ~free: no duplicated
+                # bytes, no transient ~2× depth disk usage, and no whole-set copy
+                # into a tmpfs /tmp. ffmpeg reads through them; resolve to an
+                # absolute target so the link works from the temp dir.
+                for i, s in enumerate(self._depth_ts):
+                    src = depth_dir / f'{int(s["seq"]):08d}.png'
+                    if not src.exists():
+                        logger.warning(
+                            "depth pack: missing PNG for seq %s — keeping PNGs", s.get("seq"))
+                        return
+                    (stage / f"{i:06d}.png").symlink_to(src.resolve())
+                cmd = [
+                    "ffmpeg", "-y", "-loglevel", "error",
+                    "-framerate", f"{float(self.fps):.3f}",
+                    "-start_number", "0", "-i", str(stage / "%06d.png"),
+                    "-c:v", "ffv1", "-level", "3", "-pix_fmt", "gray16le", str(out),
+                ]
+                result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                logger.error("depth pack ffmpeg failed: %s", result.stderr[-300:])
+                if out.exists():
+                    out.unlink()
+                return
+            shutil.rmtree(depth_dir)
+            logger.info("oakd depth packed → %s (%d frames)", out.name, len(self._depth_ts))
+        except Exception as e:
+            logger.warning("depth pack failed (%s) — keeping PNGs", e)
 
     def shutdown(self) -> None:
         """Stop the pipeline and exit all drainer threads."""


### PR DESCRIPTION
Before, depth frames were recorded in png files but that took a lot of time of download in HF spaces.
Now, it's converted in mkv format, to fasten the download. 