### PR TITLE
Manage the pisugar power cut.

### DIFF
--- a/packages/grabette/grabette/app/routers/system.py
+++ b/packages/grabette/grabette/app/routers/system.py
@@ -15,8 +15,51 @@ router = APIRouter(prefix="/api/system", tags=["system"])
 # dispatch must all use this identical string or the NOPASSWD match fails.
 _POWEROFF_CMD = ("/usr/bin/systemctl", "poweroff")
 
+# PiSugar 3 power-management registers (I2C 0x57). Confirmed against the
+# pisugar-power-manager-rs driver and validated on-device: the P3 has no
+# force-shutdown opcode — cutting power means clearing the output-enable bit
+# (bit 5) of control register 0x02. Protected registers must be unlocked by
+# writing 0x29 to 0x0B *before each* write (the firmware re-locks after every
+# one). Register 0x09 is a countdown in seconds after which the rail is cut;
+# its timing is loose and tends to undershoot, so keep the value generous.
+_PISUGAR_ADDR = 0x57
+_PISUGAR_WRITE_ENABLE = 0x0B
+_PISUGAR_UNLOCK = 0x29
+_PISUGAR_COUNTDOWN = 0x09
+_PISUGAR_CTRL1 = 0x02
+_PISUGAR_OUTPUT_BIT = 1 << 5
+
 
 _battery_ema: float | None = None
+
+
+def _pisugar_cut_power(delay_s: int = 30) -> bool:
+    """Arm the PiSugar 3 UPS to physically cut its 5V rail after ``delay_s``.
+
+    Without this, `systemctl poweroff` halts the OS but the battery-backed UPS
+    keeps feeding the board, so it never actually powers down (the red PWR LED
+    and the PiSugar's own LED stay lit). Arming the countdown here lets the OS
+    halt cleanly first, then the PiSugar removes power for a true power-off.
+
+    Best-effort: on a device with no PiSugar (or if I2C is unavailable) this
+    returns False and the caller still proceeds with the OS poweroff.
+    """
+    try:
+        import smbus2
+        bus = smbus2.SMBus(1)
+        try:
+            # Set the shutdown countdown (protected register).
+            bus.write_byte_data(_PISUGAR_ADDR, _PISUGAR_WRITE_ENABLE, _PISUGAR_UNLOCK)
+            bus.write_byte_data(_PISUGAR_ADDR, _PISUGAR_COUNTDOWN, delay_s & 0xFF)
+            # Clear the output-enable bit to start the countdown to cut power.
+            ctrl1 = bus.read_byte_data(_PISUGAR_ADDR, _PISUGAR_CTRL1)
+            bus.write_byte_data(_PISUGAR_ADDR, _PISUGAR_WRITE_ENABLE, _PISUGAR_UNLOCK)
+            bus.write_byte_data(_PISUGAR_ADDR, _PISUGAR_CTRL1, ctrl1 & ~_PISUGAR_OUTPUT_BIT)
+        finally:
+            bus.close()
+        return True
+    except Exception:
+        return False
 
 
 def _pisugar_battery() -> float | None:
@@ -153,6 +196,12 @@ async def system_shutdown():
             status_code=500,
             detail="Shutdown not permitted. Run 'make install-poweroff' on the device.",
         )
+
+    # On a battery-backed device, `systemctl poweroff` only halts the OS — the
+    # PiSugar UPS keeps the board powered. Arm the UPS to cut its 5V rail after
+    # a short delay so the OS finishes halting first, then power actually drops.
+    # No-op (harmless) on devices without a PiSugar.
+    _pisugar_cut_power(30)
 
     # Dispatch detached so the 200 below is sent before the box goes down.
     await asyncio.create_subprocess_exec(

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -40,7 +40,7 @@ MODAL_CSS = """
 }
 /* "Power Off" is the last navbar entry — push it to the far right and tint it
    red so it reads as separate from the normal pages. Best-effort: relies on the
-   navbar being a flex row (gradio 6.x); the ⏻ label is the guaranteed cue. */
+   navbar being a flex row (gradio 6.x); the 🔴 label is the guaranteed cue. */
 #grabette-nav a:last-child {
     margin-left: auto !important;
     color: #f87171 !important;
@@ -1411,7 +1411,7 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
     # Page 5 — Power Off
     # ══════════════════════════════════════════════════════════════════
 
-    with demo.route("⏻ Power Off") as poweroff_demo:
+    with demo.route("🔴 Power Off") as poweroff_demo:
         gr.Navbar(main_page_name="Episodes", elem_id="grabette-nav")
         gr.HTML(_TITLE_HTML)
 


### PR DESCRIPTION
Before, the shutdown button on the dashboard did not shut down the pisugar (the red and blue LED were still on, and it needed a manual turn off to be turned on again)
Now there is also a I2C sequence to make the PiSugar shutdown (takes about 20-30s)