### PR TITLE
43 mismatch between capture from dashboard and from grabette

### DIFF
--- a/packages/grabette/grabette/backend/base.py
+++ b/packages/grabette/grabette/backend/base.py
@@ -1,12 +1,60 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 
 from grabette.models import CaptureStatus, SensorState
 
+logger = logging.getLogger(__name__)
+
 
 class Backend(ABC):
+    def __init__(self) -> None:
+        # Optional capture-state LED, registered by the physical-button daemon
+        # (see ButtonListener). The backend drives it on the shared capture
+        # path so every trigger source — physical button, dashboard REST, fleet
+        # relay — gets the same LED feedback. None when no LED hardware exists.
+        self._led = None
+
+    def set_led_controller(self, led) -> None:
+        """Register the capture-state LED (object with led_on/off/blink).
+
+        The owner (ButtonListener) keeps the hardware lifecycle; the backend
+        only drives feedback during start_capture/stop_capture.
+        """
+        self._led = led
+
+    # -- LED feedback helpers (no-op when no LED is registered) -----------------
+    # All swallow errors: an LED/GPIO glitch must never break a capture.
+
+    def _led_recording(self) -> None:
+        """Solid LED — recording is live."""
+        if self._led is None:
+            return
+        try:
+            self._led.led_on()
+        except Exception:
+            logger.exception("LED on failed")
+
+    def _led_saving(self) -> None:
+        """Blinking LED — warming up / saving (capture not yet, or no longer, live)."""
+        if self._led is None:
+            return
+        try:
+            self._led.led_blink()
+        except Exception:
+            logger.exception("LED blink failed")
+
+    def _led_idle(self) -> None:
+        """LED off — idle / ready / error."""
+        if self._led is None:
+            return
+        try:
+            self._led.led_off()
+        except Exception:
+            logger.exception("LED off failed")
+
     @abstractmethod
     async def start(self) -> None: ...
 

--- a/packages/grabette/grabette/backend/mock.py
+++ b/packages/grabette/grabette/backend/mock.py
@@ -20,6 +20,7 @@ IMU_HZ = 200
 
 class MockBackend(Backend):
     def __init__(self) -> None:
+        super().__init__()
         self._running = False
         self._start_time: float | None = None
         self._capturing = False

--- a/packages/grabette/grabette/backend/rpi.py
+++ b/packages/grabette/grabette/backend/rpi.py
@@ -32,6 +32,7 @@ class RpiBackend(Backend):
         self, enable_angle: bool = False, enable_oakd: bool = True,
         oakd_keepalive_s: float = 30.0,
     ) -> None:
+        super().__init__()
         self._running = False
         self._start_time: float | None = None
         self._capturing = False
@@ -357,52 +358,66 @@ class RpiBackend(Backend):
             raise RuntimeError("Already capturing")
 
         self._starting = True
+        # Blink while the start path runs — it may spend several seconds warming
+        # up the OAK-D before the recording clock starts. Driven here (not in the
+        # button daemon) so dashboard- and fleet-initiated captures get the same
+        # LED feedback as a physical button press. Goes solid only once recording
+        # is genuinely live; off on failure.
+        self._led_saving()
         import asyncio
         loop = asyncio.get_event_loop()
 
-        # A new capture cancels any pending OAK-D keep-alive power-down.
-        self._cancel_oakd_keepalive()
+        try:
+            # A new capture cancels any pending OAK-D keep-alive power-down.
+            self._cancel_oakd_keepalive()
 
-        # Auto-connect the OAK-D if it's currently off — recording without
-        # depth/IMU is rarely what the user wants, and this matches the UI
-        # convention that toggling on/off is the "intent" flag. Errors during
-        # init are logged inside _init_oakd and leave _oakd=None; the rest
-        # of start_capture handles that gracefully. We then own its power and
-        # will auto-power-down after the keep-alive window once capture stops.
-        if not self.is_oakd_initialized:
-            await self.set_oakd_enabled(True)
-            self._oakd_auto_enabled = True
+            # Auto-connect the OAK-D if it's currently off — recording without
+            # depth/IMU is rarely what the user wants, and this matches the UI
+            # convention that toggling on/off is the "intent" flag. Errors during
+            # init are logged inside _init_oakd and leave _oakd=None; the rest
+            # of start_capture handles that gracefully. We then own its power and
+            # will auto-power-down after the keep-alive window once capture stops.
+            if not self.is_oakd_initialized:
+                await self.set_oakd_enabled(True)
+                self._oakd_auto_enabled = True
 
-        # Safety net: the previous stop_capture schedules the camera re-init to
-        # run during idle (see stop_capture). If a restart beats it, do it now.
-        if self._needs_reinit:
-            self._reinit_hardware()
+            # Safety net: the previous stop_capture schedules the camera re-init
+            # to run during idle (see stop_capture). If a restart beats it, do
+            # it now.
+            if self._needs_reinit:
+                self._reinit_hardware()
 
-        # Defer the recording clock until the OAK-D is producing valid frames
-        # (autoexposure + depth converged), so t=0 lands on good data instead
-        # of cold-boot warmup. No-op/fast if the OAK-D is already warm.
-        if self._oakd and self._oakd.is_initialized:
-            await loop.run_in_executor(
-                None, self._oakd.wait_until_ready, OAKD_READY_TIMEOUT_S,
-            )
+            # Defer the recording clock until the OAK-D is producing valid frames
+            # (autoexposure + depth converged), so t=0 lands on good data instead
+            # of cold-boot warmup. No-op/fast if the OAK-D is already warm.
+            if self._oakd and self._oakd.is_initialized:
+                await loop.run_in_executor(
+                    None, self._oakd.wait_until_ready, OAKD_READY_TIMEOUT_S,
+                )
 
-        self._capture_session_dir = session_dir
+            self._capture_session_dir = session_dir
 
-        # Set flag BEFORE starting streams so the daemon poll loop
-        # (get_state) reads from capture buffers instead of doing
-        # direct I2C reads that would contend with the angle capture thread.
-        self._starting = False
-        self._capturing = True
+            # Set flag BEFORE starting streams so the daemon poll loop
+            # (get_state) reads from capture buffers instead of doing
+            # direct I2C reads that would contend with the angle capture thread.
+            self._capturing = True
 
-        # Start synchronized capture — all streams share the same
-        # SyncManager t=0 reference (time.monotonic based).
-        self._sync.start()
-        if self._angle:
-            self._angle.start_capture()
-        if self._oakd and self._oakd.is_initialized:
-            self._oakd.start_recording(session_dir)
-        self._camera.start_recording(session_dir / "raw_video.mp4")
+            # Start synchronized capture — all streams share the same
+            # SyncManager t=0 reference (time.monotonic based).
+            self._sync.start()
+            if self._angle:
+                self._angle.start_capture()
+            if self._oakd and self._oakd.is_initialized:
+                self._oakd.start_recording(session_dir)
+            self._camera.start_recording(session_dir / "raw_video.mp4")
+        except Exception:
+            self._led_idle()
+            raise
+        finally:
+            self._starting = False
 
+        # Recording is live — solid LED.
+        self._led_recording()
         logger.info("RpiBackend capture started → %s", session_dir)
 
     async def stop_capture(self) -> CaptureStatus:
@@ -410,6 +425,18 @@ class RpiBackend(Backend):
             raise RuntimeError("Not capturing")
 
         self._starting = False
+        # Acknowledge the stop immediately: capture ends at once, but the mp4
+        # mux below takes a few seconds. Blink to show "saving" instead of a
+        # solid LED (which would read as "still recording"). The finally turns
+        # it off when the save completes. Driven here so dashboard/fleet stops
+        # get the same feedback as a button press.
+        self._led_saving()
+        try:
+            return await self._stop_capture()
+        finally:
+            self._led_idle()
+
+    async def _stop_capture(self) -> CaptureStatus:
         # Keep _capturing = True until ALL streams have stopped, to
         # prevent the daemon poll loop (get_state) from doing direct
         # I2C reads while the angle capture thread is still running.

--- a/packages/grabette/grabette/button_listener.py
+++ b/packages/grabette/grabette/button_listener.py
@@ -3,10 +3,13 @@
 Runs in a daemon thread, polls the Grove LED Button, and triggers
 capture start/stop through the same code path as the REST API.
 
-LED feedback:
-  - Blink: daemon starting / sensors initializing
-  - Off:   idle, ready for capture
+The LED hardware is owned here but registered with the backend
+(set_led_controller), which drives the capture-state feedback so every
+trigger source — button, dashboard, fleet relay — behaves identically:
+  - Blink: warming up / saving
   - Solid: recording in progress
+  - Off:   idle, ready for capture
+This listener only drives the LED directly for the teleop send toggle.
 """
 
 from __future__ import annotations
@@ -41,6 +44,13 @@ class ButtonListener:
         except Exception as e:
             logger.info("Button not available: %s", e)
             return
+
+        # Hand the LED to the backend so it drives recording feedback on the
+        # shared capture path — a capture started from the dashboard (or fleet
+        # relay) then lights the LED exactly like a button press. We still own
+        # the hardware (lifecycle + cleanup) and keep driving the LED for the
+        # teleop send toggle, which is button-only.
+        self._backend.set_led_controller(self._button)
 
         self._stop_event.clear()
         self._thread = threading.Thread(
@@ -119,10 +129,8 @@ class ButtonListener:
     # -- Capture actions (scheduled on the async event loop) --
 
     def _do_start_capture(self) -> None:
-        # Blink while the start coroutine runs — it may spend several seconds
-        # warming up the OAK-D before the recording clock starts. Go solid only
-        # when start_capture returns, i.e. recording is genuinely live.
-        self._button.led_blink()
+        # LED feedback (blink during warmup → solid when live → off on error) is
+        # driven by backend.start_capture so every trigger source behaves alike.
         episode_id = self._session_manager.create_episode(session_id=UNASSIGNED_ID)
         episode_dir = self._session_manager.episode_dir(episode_id)
 
@@ -131,23 +139,18 @@ class ButtonListener:
         )
         try:
             future.result(timeout=20.0)
-            self._button.led_on()
             logger.info("Button capture started: %s", episode_id)
         except Exception:
             logger.exception("Button start_capture failed")
             self._session_manager.discard_pending_episode()
-            self._button.led_off()
 
     def _do_stop_capture(self) -> None:
         if not self._backend.is_capturing:
             logger.warning("Button stop ignored — not capturing")
             return
 
-        # Acknowledge the press immediately: capture stops at once, but
-        # stop_capture then spends a few seconds muxing the mp4s. Blink to
-        # show "saving" instead of leaving the LED solid (looks like it's
-        # still recording), then go off when the save completes.
-        self._button.led_blink()
+        # LED feedback (blink while muxing → off when saved/on error) is driven
+        # by backend.stop_capture so every trigger source behaves alike.
         future = asyncio.run_coroutine_threadsafe(
             self._backend.stop_capture(), self._loop,
         )
@@ -156,11 +159,9 @@ class ButtonListener:
             self._session_manager.register_episode(
                 getattr(status, "session_id", None)
             )
-            self._button.led_off()
             logger.info(
                 "Button capture stopped: %.1fs, %d frames",
                 status.duration_seconds, status.frame_count,
             )
         except Exception:
             logger.exception("Button stop_capture failed")
-            self._button.led_off()

--- a/packages/grabette/grabette/button_listener.py
+++ b/packages/grabette/grabette/button_listener.py
@@ -65,6 +65,10 @@ class ButtonListener:
             self._thread.join(timeout=2.0)
             self._thread = None
         if self._button is not None:
+            # Unregister before cleanup: the backend must not drive the LED
+            # (e.g. a stop_capture during daemon shutdown) once its gpiod lines
+            # are released below.
+            self._backend.set_led_controller(None)
             self._button.led_off()
             self._button.cleanup()
             self._button = None


### PR DESCRIPTION
Before, when capturing an episode with the dashboard, the red LED did not switch on, and if we tried to stop the episode with the Grabette button, it worked but the LED was then turning on (whereas the episode was finished). 
Now, the LED manager is in the backend, so either the physical button or the dashboard button can turn the LED on and we can use either of them to start and stop an episode (even if we used the other before). 