### PR TITLE
57 fix tmpfs writing

### DIFF
--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -229,7 +229,17 @@ def create_app() -> FastAPI:
             from grabette.ui.app import create_ui
 
             demo = create_ui()
-            app = gr.mount_gradio_app(app, demo, path="/")
+            # `allowed_paths` whitelists directories from which Gradio's
+            # `/gradio_api/file=<path>` handler will serve files to the
+            # browser. Without this, the multi-GB episode archives written
+            # to data_dir/.downloads/ pass silently through — the file
+            # exists on disk but Gradio refuses to hand it out, and the UI
+            # never surfaces a download link. Default allowed paths cover
+            # only Gradio's own cache and the OS temp dir.
+            app = gr.mount_gradio_app(
+                app, demo, path="/",
+                allowed_paths=[str(settings.data_dir / ".downloads")],
+            )
             logger.info("Gradio UI mounted at /")
         except ImportError:
             logger.warning(

--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -11,6 +12,16 @@ from fastapi.staticfiles import StaticFiles
 
 from grabette.config import settings
 from grabette.daemon import Daemon
+
+# Route Gradio's internal file cache to the SD card. Gradio copies every
+# callback-returned file path into its cache dir (defaulting to
+# tempfile.gettempdir() + '/gradio/' = /tmp/gradio/ on Pi OS) to serve it
+# via a stable /gradio_api/file=... URL. Without this, downloading a
+# multi-GB episode archive fills the /tmp tmpfs even though we already
+# routed archive staging + api_client staging to the SD card. Must be set
+# before any Gradio import so the cache-dir constant is picked up.
+os.environ.setdefault("GRADIO_TEMP_DIR", str(settings.data_dir / ".gradio-cache"))
+(settings.data_dir / ".gradio-cache").mkdir(parents=True, exist_ok=True)
 
 # Configure logging
 logging.basicConfig(

--- a/packages/grabette/grabette/app/routers/sessions.py
+++ b/packages/grabette/grabette/app/routers/sessions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
+from starlette.background import BackgroundTask
 
 from grabette.app.dependencies import get_backend
 from grabette.backend.base import Backend
@@ -182,10 +183,14 @@ def download_episode(episode_id: str, sm: SessionManager = Depends(get_session_m
         archive_path = sm.create_episode_archive(episode_id)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Episode not found")
+    # Delete the archive as soon as the response finishes streaming. Without
+    # this, every download leaks a multi-GB file into the staging dir; the
+    # SessionManager sweeps on startup but that only helps across restarts.
     return FileResponse(
         archive_path,
         media_type="application/gzip",
         filename=f"{episode_id}.tar.gz",
+        background=BackgroundTask(archive_path.unlink, missing_ok=True),
     )
 
 
@@ -199,7 +204,12 @@ def download_episodes(req: DownloadEpisodesRequest, sm: SessionManager = Depends
         raise HTTPException(status_code=400, detail="No episode IDs provided")
     archive_path = sm.create_episodes_zip(req.episode_ids)
     filename = f"episodes_{req.episode_ids[0]}.tar.gz" if len(req.episode_ids) == 1 else "episodes.tar.gz"
-    return FileResponse(archive_path, media_type="application/gzip", filename=filename)
+    return FileResponse(
+        archive_path,
+        media_type="application/gzip",
+        filename=filename,
+        background=BackgroundTask(archive_path.unlink, missing_ok=True),
+    )
 
 
 @router.get("/api/episodes/{episode_id}/video")

--- a/packages/grabette/grabette/session.py
+++ b/packages/grabette/grabette/session.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 import tarfile
 import tempfile
@@ -75,6 +76,7 @@ class SessionManager:
         self._load()
         self._migrate_legacy()
         self._ensure_unassigned()
+        self._sweep_download_staging()
         self._save()
 
     # ── Persistence ───────────────────────────────────────────────────
@@ -258,17 +260,49 @@ class SessionManager:
         shutil.rmtree(ep_dir)
         self._save()
 
+    def _new_archive_path(self, prefix: str = "download") -> Path:
+        """Return a fresh tar.gz path in the data_dir download-staging dir.
+
+        We stage under data_dir/.downloads (SD-card-backed) rather than /tmp
+        because Pi OS mounts /tmp as a tmpfs of only a few GB — a handful of
+        large episode archives will fill it and cause ENOSPC across the whole
+        daemon (live camera, capture writes, everything). The staging dir is
+        also swept on SessionManager init as a backstop for archives that
+        weren't cleaned up by the download endpoint (crashed daemon, aborted
+        client, etc.). Individual archive files are deleted by the endpoint's
+        BackgroundTask once the FileResponse finishes streaming.
+        """
+        staging = self.data_dir / ".downloads"
+        staging.mkdir(parents=True, exist_ok=True)
+        fd, path = tempfile.mkstemp(suffix=".tar.gz", prefix=f"{prefix}_", dir=staging)
+        os.close(fd)  # we only wanted the unique path; tarfile opens by name
+        return Path(path)
+
+    def _sweep_download_staging(self) -> None:
+        """Delete any leftover archives from previous sessions (crash /
+        aborted download safety net). Called from __init__ so the daemon
+        starts clean."""
+        staging = self.data_dir / ".downloads"
+        if not staging.is_dir():
+            return
+        for f in staging.glob("*.tar.gz"):
+            try:
+                f.unlink()
+                logger.info("Removed stale download archive: %s", f.name)
+            except Exception as e:
+                logger.warning("Could not remove stale archive %s: %s", f, e)
+
     def create_episode_archive(self, episode_id: str) -> Path:
         ep_dir = self.episode_dir(episode_id)
         if not ep_dir.exists():
             raise FileNotFoundError(f"Episode {episode_id} not found")
-        archive_path = Path(tempfile.mktemp(suffix=".tar.gz"))
+        archive_path = self._new_archive_path(prefix=episode_id)
         with tarfile.open(archive_path, "w:gz") as tar:
             tar.add(ep_dir, arcname=episode_id)
         return archive_path
 
     def create_episodes_zip(self, episode_ids: list[str]) -> Path:
-        archive_path = Path(tempfile.mktemp(suffix=".tar.gz"))
+        archive_path = self._new_archive_path(prefix="episodes")
         with tarfile.open(archive_path, "w:gz") as tar:
             for episode_id in episode_ids:
                 ep_dir = self.episode_dir(episode_id)

--- a/packages/grabette/grabette/session.py
+++ b/packages/grabette/grabette/session.py
@@ -281,16 +281,33 @@ class SessionManager:
     def _sweep_download_staging(self) -> None:
         """Delete any leftover archives from previous sessions (crash /
         aborted download safety net). Called from __init__ so the daemon
-        starts clean."""
+        starts clean.
+
+        Also wipes the Gradio file cache. Gradio hashes every callback-returned
+        file path and copies it into GRADIO_TEMP_DIR (routed to data_dir/
+        .gradio-cache to keep it off the /tmp tmpfs). Gradio never sweeps
+        this cache itself, so without this every downloaded archive would
+        accumulate forever on the SD card. A daemon restart is rare enough
+        that unconditionally clearing the cache costs at most one re-hash
+        on the next download.
+        """
         staging = self.data_dir / ".downloads"
-        if not staging.is_dir():
-            return
-        for f in staging.glob("*.tar.gz"):
+        if staging.is_dir():
+            for f in staging.glob("*.tar.gz"):
+                try:
+                    f.unlink()
+                    logger.info("Removed stale download archive: %s", f.name)
+                except Exception as e:
+                    logger.warning("Could not remove stale archive %s: %s", f, e)
+
+        gradio_cache = self.data_dir / ".gradio-cache"
+        if gradio_cache.is_dir() and any(gradio_cache.iterdir()):
             try:
-                f.unlink()
-                logger.info("Removed stale download archive: %s", f.name)
+                shutil.rmtree(gradio_cache)
+                gradio_cache.mkdir(parents=True, exist_ok=True)
+                logger.info("Cleared Gradio file cache: %s", gradio_cache)
             except Exception as e:
-                logger.warning("Could not remove stale archive %s: %s", f, e)
+                logger.warning("Could not clear Gradio cache %s: %s", gradio_cache, e)
 
     def create_episode_archive(self, episode_id: str) -> Path:
         ep_dir = self.episode_dir(episode_id)

--- a/packages/grabette/grabette/ui/api_client.py
+++ b/packages/grabette/grabette/ui/api_client.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from pathlib import Path
 
 import httpx
+
+logger = logging.getLogger(__name__)
+
+# Read-response in 8 MB chunks. Large enough to keep syscall overhead low,
+# small enough that a multi-GB download never puts >8 MB in RAM at a time.
+# The old `r.content` reader buffered the whole response (>1 GB for a full
+# dataset), which OOM'd on the 4 GB Pi and silently returned None.
+_DOWNLOAD_CHUNK_BYTES = 8 * 1024 * 1024
 
 
 class GrabetteClient:
@@ -266,35 +275,46 @@ class GrabetteClient:
             return {"error": str(e)}
 
     def download_episode(self, episode_id: str) -> str | None:
+        # Stream to disk in 8 MB chunks — see _DOWNLOAD_CHUNK_BYTES. timeout=None
+        # disables the total-request deadline (large episodes can take a while);
+        # httpx still errors on stalled reads via its per-op defaults.
         try:
-            r = self._http.get(
-                f"/api/episodes/{episode_id}/download",
-                timeout=60.0,
-            )
-            r.raise_for_status()
             self._download_dir.mkdir(parents=True, exist_ok=True)
             path = str(self._download_dir / f"{episode_id}.tar.gz")
-            with open(path, "wb") as f:
-                f.write(r.content)
+            with self._http.stream(
+                "GET",
+                f"/api/episodes/{episode_id}/download",
+                timeout=None,
+            ) as r:
+                r.raise_for_status()
+                with open(path, "wb") as f:
+                    for chunk in r.iter_bytes(chunk_size=_DOWNLOAD_CHUNK_BYTES):
+                        f.write(chunk)
             return path
         except Exception:
+            # Log the real cause instead of swallowing silently — the previous
+            # bare except left the Gradio UI showing no error and no link.
+            logger.exception("download_episode(%s) failed", episode_id)
             return None
 
     def download_episodes(self, episode_ids: list[str]) -> str | None:
         try:
-            r = self._http.post(
-                "/api/episodes/download",
-                json={"episode_ids": episode_ids},
-                timeout=120.0,
-            )
-            r.raise_for_status()
             filename = "episodes.tar.gz" if len(episode_ids) > 1 else f"{episode_ids[0]}.tar.gz"
             self._download_dir.mkdir(parents=True, exist_ok=True)
             path = str(self._download_dir / filename)
-            with open(path, "wb") as f:
-                f.write(r.content)
+            with self._http.stream(
+                "POST",
+                "/api/episodes/download",
+                json={"episode_ids": episode_ids},
+                timeout=None,
+            ) as r:
+                r.raise_for_status()
+                with open(path, "wb") as f:
+                    for chunk in r.iter_bytes(chunk_size=_DOWNLOAD_CHUNK_BYTES):
+                        f.write(chunk)
             return path
         except Exception:
+            logger.exception("download_episodes(%s) failed", episode_ids)
             return None
 
     def move_episodes(self, episode_ids: list[str], target_session_id: str) -> dict:

--- a/packages/grabette/grabette/ui/api_client.py
+++ b/packages/grabette/grabette/ui/api_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from pathlib import Path
 
 import httpx
 
@@ -14,12 +15,24 @@ class GrabetteClient:
     Used by both the local Gradio dashboard and the HF Spaces app.
     """
 
-    def __init__(self, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        base_url: str | None = None,
+        download_dir: str | Path | None = None,
+    ) -> None:
         self.base_url = (
             base_url
             or os.environ.get("GRABETTE_API_URL")
             or "http://localhost:8000"
         )
+        # Where downloaded episode archives are staged before Gradio serves
+        # them to the browser. Passed explicitly by the local daemon so the
+        # multi-GB tar.gz lands on the SD card, NOT on Pi OS's tmpfs /tmp
+        # (which is small enough to fill after a couple of downloads and
+        # brick the whole daemon with ENOSPC). Falls back to the OS temp
+        # dir for callers that don't set it — fine on workstations / HF
+        # Spaces where /tmp is a normal-sized filesystem.
+        self._download_dir = Path(download_dir) if download_dir else Path(tempfile.gettempdir())
         self._http = httpx.Client(base_url=self.base_url, timeout=10.0)
 
     # -- Camera --
@@ -259,9 +272,8 @@ class GrabetteClient:
                 timeout=60.0,
             )
             r.raise_for_status()
-            path = os.path.join(
-                tempfile.gettempdir(), f"{episode_id}.tar.gz"
-            )
+            self._download_dir.mkdir(parents=True, exist_ok=True)
+            path = str(self._download_dir / f"{episode_id}.tar.gz")
             with open(path, "wb") as f:
                 f.write(r.content)
             return path
@@ -277,7 +289,8 @@ class GrabetteClient:
             )
             r.raise_for_status()
             filename = "episodes.tar.gz" if len(episode_ids) > 1 else f"{episode_ids[0]}.tar.gz"
-            path = os.path.join(tempfile.gettempdir(), filename)
+            self._download_dir.mkdir(parents=True, exist_ok=True)
+            path = str(self._download_dir / filename)
             with open(path, "wb") as f:
                 f.write(r.content)
             return path

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -236,7 +236,15 @@ def _upload_progress_md(repo_id: str, rows: list[dict], finished: bool) -> str:
 
 
 def create_ui(api_url: str | None = None) -> gr.Blocks:
-    client = GrabetteClient(base_url=api_url)
+    # Route downloaded episode archives to the SD-card-backed data_dir
+    # instead of the OS /tmp (which on Pi OS is a small tmpfs). Same reason
+    # as the SessionManager staging; the SessionManager's startup sweep
+    # cleans this same directory across daemon restarts.
+    from grabette.config import settings
+    client = GrabetteClient(
+        base_url=api_url,
+        download_dir=settings.data_dir / ".downloads",
+    )
 
     # ── Camera ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Rasp will crash when downloading a "big" dataset as zip is being made in tmpfs.
This fixes that