### PR TITLE
docs: correct teleop rig (OAK-D SR) + note scene-dependent sim physic…

### DIFF
--- a/integrations/openarm/openarm_gripette_simu/README.md
+++ b/integrations/openarm/openarm_gripette_simu/README.md
@@ -310,7 +310,7 @@ Camera rendering is done in the main thread (alongside physics and viewer) and c
 
 | Component | Rate |
 |-----------|------|
-| Physics | 500Hz (dt=0.002s) |
+| Physics | 500Hz (dt=0.002s) default; 1000Hz (dt=0.001s) in the grasp scenes |
 | Camera render | 30Hz (matches the real Grabette stream) |
 | Gripper gRPC stream | 30Hz |
 | Dataset FPS | 30 (grasp, matches real) · 50 (reach) |

--- a/packages/grabette/docs/teleop.md
+++ b/packages/grabette/docs/teleop.md
@@ -175,7 +175,7 @@ where messages are being dropped.
 ## Tuning
 
 All knobs are CLI flags. Defaults are tuned for **sim** + a real
-BMI088-equipped Grabette at 320×200 BasaltVIO.
+OAK-D SR Grabette at 320×200 BasaltVIO.
 
 | Flag | Default | Purpose |
 |---|---|---|


### PR DESCRIPTION
…s dt

teleop.md: live BasaltVIO teleop runs on the OAK-D SR, not the legacy BMI088 (oakd_teleop.py); 320x200 verified unchanged. simu README: physics timestep is scene-dependent — 0.002s/500Hz default, 0.001s/1000Hz in the grasp scenes (table_grasp.xml, grabette_grasp.xml).