### PR TITLE
ci: add lerobot-boundary test lane (guards dependency bumps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,16 +95,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - name: Install FFmpeg
+        # lerobot[dataset]'s video path uses torchcodec, which dlopens the system
+        # FFmpeg libraries (libavutil.so.* / libavcodec.so.* …) at runtime. A bare
+        # ubuntu-latest runner has none, so build_dataset fails at video encode.
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Lerobot-dependent tests (CPU torch)
         # CPU-only torch via `uv pip install --torch-backend=cpu` (~200 MB); a
         # plain workspace sync installs the CUDA wheel (~2.5 GB) — the tests use
         # no GPU. The lerobot spec is read from the postprocess pyproject so the
-        # tested version tracks the pin automatically (no drift).
+        # tested version tracks the pin automatically (no drift). cv2 comes from
+        # lerobot's opencv-python-headless — all the tests need (no GUI); no
+        # separate opencv-python.
         run: |
           SPEC=$(grep -oE "lerobot\[[a-z,]*\]==[0-9.]+" packages/grabette-postprocess/pyproject.toml | head -1)
           echo "Testing against: $SPEC"
           uv venv .venv-lerobot --python 3.12
-          VIRTUAL_ENV=.venv-lerobot uv pip install --torch-backend=cpu "$SPEC" pytest opencv-python pandas scipy av
+          VIRTUAL_ENV=.venv-lerobot uv pip install --torch-backend=cpu "$SPEC" pytest pandas scipy av
           PYTHONPATH=packages/grabette-postprocess .venv-lerobot/bin/python -m pytest \
             packages/grabette-postprocess/tests/test_lerobot_api.py \
             packages/grabette-postprocess/tests/test_dataset_build.py -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,33 @@ jobs:
         # Trajectory math + SLAM-quality / recording checks + episode tags.
         # Pure Python (numpy/scipy/pandas/av), no Docker/SLAM. lerobot (torch)
         # is skipped: the __init__ is empty so these modules don't import it,
-        # and leaving it out keeps the job fast.
+        # and leaving it out keeps the job fast. The lerobot-dependent tests in
+        # this dir self-skip here (pytest.importorskip) and run in the 'lerobot'
+        # job below.
         run: |
           uv sync --package grabette-postprocess --extra test --no-install-package lerobot
           uv run --no-sync --package grabette-postprocess pytest packages/grabette-postprocess/tests -q
+
+  lerobot:
+    # Guards the lerobot boundary so a dependency bump can't silently regress it
+    # (e.g. the vcodec->rgb_encoder break). Runs the tests that need lerobot
+    # actually installed — Tier A API-surface tripwires + Tier B synthetic
+    # build_dataset round-trip — which the fast 'tests' job skips via
+    # pytest.importorskip("lerobot").
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Lerobot-dependent tests (CPU torch)
+        # CPU-only torch via `uv pip install --torch-backend=cpu` (~200 MB); a
+        # plain workspace sync installs the CUDA wheel (~2.5 GB) — the tests use
+        # no GPU. The lerobot spec is read from the postprocess pyproject so the
+        # tested version tracks the pin automatically (no drift).
+        run: |
+          SPEC=$(grep -oE "lerobot\[[a-z,]*\]==[0-9.]+" packages/grabette-postprocess/pyproject.toml | head -1)
+          echo "Testing against: $SPEC"
+          uv venv .venv-lerobot --python 3.12
+          VIRTUAL_ENV=.venv-lerobot uv pip install --torch-backend=cpu "$SPEC" pytest opencv-python pandas scipy av
+          PYTHONPATH=packages/grabette-postprocess .venv-lerobot/bin/python -m pytest \
+            packages/grabette-postprocess/tests/test_lerobot_api.py \
+            packages/grabette-postprocess/tests/test_dataset_build.py -v

--- a/packages/grabette-postprocess/tests/test_dataset_build.py
+++ b/packages/grabette-postprocess/tests/test_dataset_build.py
@@ -1,0 +1,81 @@
+"""Tier B — functional build_dataset round-trip against the installed lerobot.
+
+Fabricates a tiny synthetic episode (two 4-frame videos + timestamps +
+trajectory CSV + angles), runs dataset.build_dataset (the real create ->
+add_frame -> save_episode -> finalize flow, incl. rgb_encoder h264 encoding),
+then reloads the produced LeRobotDataset and asserts schema / counts / values.
+
+This is the functional guard for a lerobot bump: if 0.x.0 breaks the builder,
+this fails where the API-surface test can't. Skipped when lerobot is absent.
+"""
+import json
+import os
+
+import numpy as np
+import pytest
+
+pytest.importorskip("lerobot", reason="lerobot not installed (fast lane)")
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
+import cv2  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from grabette_postprocess.dataset import build_dataset  # noqa: E402
+
+N = 4
+TS_MS = [0, 33, 66, 100]
+COLS = ["frame_idx", "timestamp", "state", "is_lost", "is_keyframe",
+        "x", "y", "z", "q_x", "q_y", "q_z", "q_w"]
+
+
+def _write_video(path, n, w=128, h=96):
+    vw = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), 30.0, (w, h))
+    assert vw.isOpened(), f"could not open VideoWriter for {path}"
+    for i in range(n):
+        frame = np.full((h, w, 3), i * 30, dtype=np.uint8)  # distinct per frame
+        vw.write(frame)
+    vw.release()
+
+
+def _make_episode(ep_dir):
+    ep_dir.mkdir(parents=True)
+    _write_video(ep_dir / "raw_video.mp4", N)
+    _write_video(ep_dir / "oakd_left.mp4", N)
+    (ep_dir / "frame_timestamps.json").write_text(json.dumps(TS_MS))
+    (ep_dir / "oakd_left_timestamps.json").write_text(
+        json.dumps({"samples": [{"host_ms": t} for t in TS_MS]}))
+    (ep_dir / "angle_data.json").write_text(json.dumps({"samples": [
+        {"cts": t, "value": [0.1 * i, 0.2 * i]} for i, t in enumerate(TS_MS)]}))
+    # trajectory: 4 tracked frames, moving along +x, identity rotation
+    rows = [[i, TS_MS[i] / 1000.0, "OK", 0, 0, 0.01 * i, 0.0, 0.0, 0, 0, 0, 1]
+            for i in range(N)]
+    pd.DataFrame(rows, columns=COLS).to_csv(ep_dir / "camera_trajectory.csv", index=False)
+    return ep_dir
+
+
+def test_build_dataset_roundtrip(tmp_path):
+    ep = _make_episode(tmp_path / "ep0")
+    root = tmp_path / "ds"
+    repo_id = "test/grabette_synthetic"
+
+    build_dataset(repo_id, [ep], task="pick", fps=30, root=root)
+
+    # Reload the produced dataset and assert schema + counts + values.
+    from lerobot.datasets import LeRobotDataset
+    ds = LeRobotDataset(repo_id, root=root)
+
+    feats = ds.meta.features
+    assert feats["observation.images.cam0"]["dtype"] == "video"
+    assert feats["observation.images.cam1"]["dtype"] == "video"
+    assert tuple(feats["action"]["shape"]) == (8,)
+    assert "is_lost" in feats
+
+    assert ds.meta.total_episodes == 1
+    assert ds.meta.total_frames == N
+    assert ds.fps == 30
+
+    # action[0] = [x,y,z, ax,ay,az, proximal, distal]; frame 0 -> zeros
+    sample = ds[0]
+    action = np.asarray(sample["action"]).ravel()
+    assert action.shape == (8,)
+    np.testing.assert_allclose(action[:6], 0.0, atol=1e-5)  # first pose = origin+identity

--- a/packages/grabette-postprocess/tests/test_lerobot_api.py
+++ b/packages/grabette-postprocess/tests/test_lerobot_api.py
@@ -1,0 +1,49 @@
+"""Tier A — lerobot API-surface tripwires.
+
+Asserts the exact lerobot symbols/signatures grabette-postprocess (dataset.py)
+and the DiffusionPolicy integration depend on. Fails loudly + specifically when
+a lerobot bump removes/renames/moves one — the class of change that has silently
+broken the pipeline before (vcodec kwarg dropped, `datasets` moved to an extra).
+
+Skipped entirely when lerobot isn't installed (the fast pure-Python CI lane).
+"""
+import inspect
+
+import pytest
+
+pytest.importorskip("lerobot", reason="lerobot not installed (fast lane)")
+
+
+def test_lerobot_dataset_importable_from_top_level():
+    from lerobot.datasets import LeRobotDataset, LeRobotDatasetMetadata  # noqa: F401
+
+
+def test_rgb_encoder_config_importable():
+    from lerobot.configs import RGBEncoderConfig  # noqa: F401
+
+
+def test_create_takes_rgb_encoder_not_vcodec():
+    from lerobot.datasets import LeRobotDataset
+    params = inspect.signature(LeRobotDataset.create).parameters
+    assert "rgb_encoder" in params, f"create() params: {list(params)}"
+    assert "vcodec" not in params, "vcodec still present — dataset.py migration mismatch"
+
+
+def test_rgb_encoder_config_accepts_vcodec():
+    from lerobot.configs import RGBEncoderConfig
+    RGBEncoderConfig(vcodec="h264")
+
+
+def test_create_takes_streaming_encoding():
+    from lerobot.datasets import LeRobotDataset
+    assert "streaming_encoding" in inspect.signature(LeRobotDataset.create).parameters
+
+
+def test_recompute_stats_available():
+    # Used by DiffusionPolicy/convert_dataset.py
+    from lerobot.datasets.dataset_tools import recompute_stats  # noqa: F401
+
+
+def test_hf_datasets_present():
+    # `datasets` (HF) was historically moved to an extra; the pipeline needs it.
+    import datasets  # noqa: F401


### PR DESCRIPTION
New CI 'lerobot' job runs the tests that need lerobot actually installed — Tier A API-surface tripwires (LeRobotDataset/RGBEncoderConfig/create(rgb_encoder)/recompute_stats/...) + Tier B synthetic build_dataset round-trip — which the fast 'tests' job skips via pytest.importorskip. Installs CPU-only torch (uv pip --torch-backend=cpu, ~200MB; a workspace sync pulls the ~2.5GB CUDA wheel) and reads the lerobot spec from the postprocess pyproject so the tested version tracks the pin (no drift). This would have caught the 0.5.1->0.6.0 vcodec->rgb_encoder break automatically. Fast job now: 30 passed, 2 skipped; lerobot job: 8 passed.