### PR TITLE
docs: document the gripette grip-force cap + present_load

### DIFF
--- a/integrations/openarm/openarm_gripette_simu/README.md
+++ b/integrations/openarm/openarm_gripette_simu/README.md
@@ -59,9 +59,9 @@ Identical to the real [Gripette](../../../packages/gripette) gRPC API.
 
 | RPC | Description |
 |-----|-------------|
-| `StreamState` | 30Hz JPEG camera frames + motor positions + timestamp |
-| `SendMotorCommand(m1, m2)` | Set gripper joint goals (rad) |
-| `ReadMotors` | Read gripper joint positions (rad) |
+| `StreamState` | 30Hz JPEG camera frames + motor positions + load + timestamp |
+| `SendMotorCommand(m1, m2[, torque_limit])` | Set gripper joint goals (rad); optional grip force cap (0..1, 0 = unset) |
+| `ReadMotors` | Read gripper joint positions (rad) + load |
 | `SetTorque(enable)` | No-op in simulation |
 | `Ping` | Health check |
 
@@ -245,8 +245,9 @@ uv run python examples/evaluate.py \
 
 - `--checkpoint` — local path or HF repo id.
 - `--n_action_steps 8` — committed grasp (lower = more reactive approach, but can hesitate on the trigger).
-- `--debug` — preview the camera feed; `--log_gripper` — print the gripper command vs observed state each step.
+- `--debug` — preview the camera feed; `--log_gripper` — print the gripper command vs observed state (and `present_load`) each step.
 - `--clamp_pos_mm` / `--clamp_rot_deg` — cap per-step Cartesian deltas (stability test).
+- `--grip_torque_limit` — **grip force cap** as a fraction `0..1` of the servo's max torque, applied to both gripper DOFs. `0` (default) = full torque = the pre-existing behavior, so **existing policies are unaffected unless you opt in**. With a cap set, the DOF driven into the object stalls at the cap → a consistent, object-size-independent grip force, while the policy's position targets (grasp *shape*) are untouched — no shape classifier needed. Force is then the cap, not `--grip_gain`×overshoot, so `--grip_gain` only needs to push the closing target past contact. Real hardware only (no-op in sim, which has no torque cap). Start around `0.25` (field-validated: "medium" grip, ample for grasping, and thermally safe to hold indefinitely — no overload-protection fade); watch the `motor{1,2}_load` telemetry via `--log_gripper`. Load clamps at `cap×1000`; `present_current` keeps rising past the cap if you need to sense firmer grasps.
 
 **OpenCV: headless by default, GUI window opt-in.** The workspace installs **`opencv-python-headless`** — lerobot depends on it and the on-device services (grabette on the Pi) need it, and a single venv can hold only one `cv2`. In this default, `--debug` **saves annotated frames to `eval_debug_frames/`** (and warns once) instead of opening a window. To get a **live preview window** on a GUI workstation, install the full build over the headless one:
 

--- a/packages/gripette/docs/configuration.md
+++ b/packages/gripette/docs/configuration.md
@@ -12,6 +12,14 @@ All motor positions in the API (gRPC, client, scripts, limits) are in **robot fr
 
 Commands outside these bounds are rejected with `ValueError` before reaching the bus. `MotorController` bridges robot frame ↔ encoder frame via per-motor `sign` (from `hand`) and `offset` (from calibration); callers never deal with the encoder values directly.
 
+## Grip force cap & load feedback
+
+`SendMotorCommand` accepts an optional per-motor **torque limit** (`motor{1,2}_torque_limit`, a fraction `0..1` of the servo's max torque). It writes the servo's *running* (RAM) torque-limit register — **not** the EEPROM max-torque register — so it is safe to set every grasp; the value is deduplicated and only written when it changes. A value of `0` means *unset*: the limit is left untouched (full torque), so this is fully backward-compatible — a client that never sets it behaves exactly as before.
+
+Capping the torque turns grip force into a bounded, object-size-independent quantity: the closing joint stalls at the cap instead of pushing to a position error. See the eval-side `--grip_torque_limit` flag in the [simulator/eval README](../../../integrations/openarm/openarm_gripette_simu/README.md).
+
+`MotorState` reports `motor{1,2}_load` — the servo's decoded `present_load` (control effort, ~PWM) in **robot frame: positive = closing effort** (matching the angle convention), consistent across left/right via the per-motor `sign`. The sign is preserved, so an external force driving a joint the *other* way reads negative. Load magnitude clamps at the active torque limit; `present_load` is ~0 whenever torque is disabled. (Sign polarity was calibrated on a right-hand unit — verify on a left unit before trusting its load sign.)
+
 ## Environment variables
 
 All settings via environment variables with `GRIPPER_` prefix. Persistent per-device config lives in `/etc/gripette/env`, sourced by `gripette.service`.


### PR DESCRIPTION
User-facing docs for the torque-limit grasp feature (code merged in #101):
- eval README: --grip_torque_limit flag (opt-in force cap, 0=full torque=old behavior, real-hw only, start ~0.25), --log_gripper now shows load, and the gRPC API table reflects the new optional torque_limit / load fields
- gripette configuration.md: 'Grip force cap & load feedback' — RAM (not EEPROM) running torque-limit, backward-compatible 0=unset, and robot-frame present_load (positive=closing, sign preserved, left-unit verify caveat)