### PR TITLE
111 fix sessions issue on dashboard

### DIFF
--- a/packages/grabette/grabette/app/routers/sessions.py
+++ b/packages/grabette/grabette/app/routers/sessions.py
@@ -31,6 +31,10 @@ class UpdateSessionRequest(BaseModel):
     description: str | None = None
 
 
+class SetActiveSessionRequest(BaseModel):
+    session_id: str
+
+
 @router.get("/api/sessions")
 def list_sessions(sm: SessionManager = Depends(get_session_manager)):
     return sm.list_sessions()
@@ -43,6 +47,26 @@ def create_session(
 ):
     session_id = sm.create_session(req.name, req.description)
     return sm.get_session(session_id)
+
+
+# The two /api/sessions/active routes MUST stay above their
+# /api/sessions/{session_id} counterparts: FastAPI matches in declaration
+# order, so a "{session_id}" route declared first swallows "active" and
+# answers 404 "Session not found" instead.
+@router.get("/api/sessions/active")
+def get_active_session(sm: SessionManager = Depends(get_session_manager)):
+    return {"session_id": sm.active_session_id}
+
+
+@router.put("/api/sessions/active")
+def set_active_session(
+    req: SetActiveSessionRequest,
+    sm: SessionManager = Depends(get_session_manager),
+):
+    if sm._find_session(req.session_id) is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    sm.active_session_id = req.session_id
+    return {"session_id": sm.active_session_id}
 
 
 @router.get("/api/sessions/{session_id}")
@@ -92,26 +116,6 @@ class MoveEpisodesRequest(BaseModel):
 
 class StartCaptureRequest(BaseModel):
     session_id: str | None = None
-
-
-class SetActiveSessionRequest(BaseModel):
-    session_id: str
-
-
-@router.get("/api/sessions/active")
-def get_active_session(sm: SessionManager = Depends(get_session_manager)):
-    return {"session_id": sm.active_session_id}
-
-
-@router.put("/api/sessions/active")
-def set_active_session(
-    req: SetActiveSessionRequest,
-    sm: SessionManager = Depends(get_session_manager),
-):
-    if sm._find_session(req.session_id) is None:
-        raise HTTPException(status_code=404, detail="Session not found")
-    sm.active_session_id = req.session_id
-    return {"session_id": sm.active_session_id}
 
 
 @router.get("/api/capture-session/status")

--- a/packages/grabette/grabette/session.py
+++ b/packages/grabette/grabette/session.py
@@ -358,6 +358,18 @@ class SessionManager:
         if not imu_present and any(p.exists() for p in imu_paths):
             issues.append("empty IMU log")
 
+        # oakd_calib.json is written by start_recording(), so it marks the
+        # episodes that actually ran an OAK-D. oakd_left.mp4 is the anchor the
+        # SLAM export globs on: without it the episode is silently missing
+        # from the pushed dataset. A leftover .h264 means the mux never ran.
+        if (ep_dir / "oakd_calib.json").exists():
+            if not self._has_data(ep_dir / "oakd_left.mp4"):
+                issues.append("no OAK-D video")
+            if not (ep_dir / "oakd_imu.json").exists():
+                issues.append("no OAK-D IMU")
+            if any((ep_dir / f"oakd_{s}.h264").exists() for s in ("left", "right")):
+                issues.append("unmuxed OAK-D stream")
+
         duration = 0.0
         frame_count = 0
         imu_sample_count = 0

--- a/packages/grabette/grabette/session.py
+++ b/packages/grabette/grabette/session.py
@@ -339,7 +339,16 @@ class SessionManager:
         angle_sample_count = 0
         meta_path = ep_dir / "metadata.json"
         if meta_path.exists():
-            meta = json.loads(meta_path.read_text())
+            # A capture cut short (power loss, daemon kill, full SD card) can
+            # leave metadata.json empty or truncated. Same policy as _load()
+            # for a corrupt registry: warn and fall back to zeroed counters,
+            # so one damaged episode degrades to "0 frames" instead of
+            # raising out of list_sessions() and blanking the whole dashboard.
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning("Corrupt metadata.json for episode %s: %s", episode_id, e)
+                meta = {}
             duration = meta.get("duration_seconds", 0.0)
             frame_count = meta.get("frame_count", 0)
             imu_sample_count = meta.get("imu_sample_count") or meta.get("oakd", {}).get("imu_samples", 0)

--- a/packages/grabette/grabette/session.py
+++ b/packages/grabette/grabette/session.py
@@ -35,6 +35,10 @@ class EpisodeInfo(BaseModel):
     angle_sample_count: int = 0
     has_video: bool = False
     has_imu: bool = False
+    # Human-readable damage report, empty for a healthy episode. Surfaced in
+    # the dashboard's Status column so a broken capture is visible and can be
+    # deleted, rather than silently listed with zeroed counters.
+    issues: list[str] = []
 
 
 class SessionInfo(BaseModel):
@@ -327,11 +331,32 @@ class SessionManager:
                     tar.add(ep_dir, arcname=episode_id)
         return archive_path
 
+    @staticmethod
+    def _has_data(path: Path) -> bool:
+        """True if the file exists *and* holds at least one byte.
+
+        An aborted capture leaves every output file created but zero-length,
+        so a bare exists() check reports has_video=True for a 0-byte mp4.
+        """
+        try:
+            return path.stat().st_size > 0
+        except OSError:
+            return False
+
     def _get_episode_info(self, episode_id: str) -> EpisodeInfo:
         ep_dir = self.episode_dir(episode_id)
+        issues: list[str] = []
+
         video_path = ep_dir / "raw_video.mp4"
+        has_video = self._has_data(video_path)
+        if video_path.exists() and not has_video:
+            issues.append("empty video")
+
         # Real (OAK-D) episodes write oakd_imu.json; mock/legacy write imu_data.json.
-        imu_present = (ep_dir / "oakd_imu.json").exists() or (ep_dir / "imu_data.json").exists()
+        imu_paths = (ep_dir / "oakd_imu.json", ep_dir / "imu_data.json")
+        imu_present = any(self._has_data(p) for p in imu_paths)
+        if not imu_present and any(p.exists() for p in imu_paths):
+            issues.append("empty IMU log")
 
         duration = 0.0
         frame_count = 0
@@ -344,10 +369,12 @@ class SessionManager:
             # for a corrupt registry: warn and fall back to zeroed counters,
             # so one damaged episode degrades to "0 frames" instead of
             # raising out of list_sessions() and blanking the whole dashboard.
+            # The failure is recorded in `issues` so it stays visible.
             try:
                 meta = json.loads(meta_path.read_text())
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning("Corrupt metadata.json for episode %s: %s", episode_id, e)
+                issues.append("unreadable metadata")
                 meta = {}
             duration = meta.get("duration_seconds", 0.0)
             frame_count = meta.get("frame_count", 0)
@@ -361,8 +388,9 @@ class SessionManager:
             frame_count=frame_count,
             imu_sample_count=imu_sample_count,
             angle_sample_count=angle_sample_count,
-            has_video=video_path.exists(),
+            has_video=has_video,
             has_imu=imu_present,
+            issues=issues,
         )
 
     # ── Session operations ────────────────────────────────────────────

--- a/packages/grabette/grabette/ui/api_client.py
+++ b/packages/grabette/grabette/ui/api_client.py
@@ -43,6 +43,10 @@ class GrabetteClient:
         # Spaces where /tmp is a normal-sized filesystem.
         self._download_dir = Path(download_dir) if download_dir else Path(tempfile.gettempdir())
         self._http = httpx.Client(base_url=self.base_url, timeout=10.0)
+        # Why the last list_sessions() returned nothing, or None if it
+        # succeeded. Without it a failing /api/sessions is indistinguishable
+        # from "no tasks yet": the dashboard just renders empty.
+        self.sessions_error: str | None = None
 
     # -- Camera --
 
@@ -216,8 +220,10 @@ class GrabetteClient:
         try:
             r = self._http.get("/api/sessions")
             r.raise_for_status()
+            self.sessions_error = None
             return r.json()
-        except Exception:
+        except Exception as e:
+            self.sessions_error = str(e)
             return []
 
     def create_session(self, name: str, description: str = "") -> dict:

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -1217,8 +1217,18 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
                 # Remembers, per browser, which task was selected so a page
                 # refresh stays on it instead of snapping back to the first
                 # task. Independent of the (server-side) capture session.
+                # `secret` must be pinned: Gradio encrypts the localStorage
+                # blob and, left unset, generates a fresh random key at every
+                # process start. After a daemon restart the browser's stored
+                # value would no longer decrypt — Gradio logs
+                # "Error reading from localStorage: SyntaxError: JSON.parse:
+                # unexpected end of data" and falls back to the default, so
+                # the selection was never actually remembered. This only
+                # obfuscates a task id, so a constant is fine.
                 selected_task_state = gr.BrowserState(
-                    "", storage_key="grabette_selected_task",
+                    "",
+                    storage_key="grabette_selected_task",
+                    secret="grabette-ui-v1",
                 )
                 new_task_btn = gr.Button("+ New Task", size="sm", variant="primary")
                 with gr.Group(visible=False) as new_task_form:

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -603,6 +603,7 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
                 task_name = s.get("name", "")
                 task_description = s.get("description", "")
                 for ep in s.get("episodes", []):
+                    issues = ep.get("issues") or []
                     rows.append([
                         False,
                         ep["episode_id"],
@@ -610,6 +611,7 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
                         ep["frame_count"],
                         ep["imu_sample_count"],
                         ep.get("angle_sample_count", 0),
+                        "⚠ " + ", ".join(issues) if issues else "ok",
                     ])
                 break
         rows.reverse()
@@ -627,6 +629,20 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
         if task_description:
             desc_parts.append(f"**Task description:** {task_description}")
         desc_parts.append(f"*{count_str} recorded*")
+        # An unreachable/erroring API used to look exactly like "no episodes
+        # yet" — an empty table and no explanation. Say which it is.
+        if client.sessions_error:
+            desc_parts.append(
+                f"🛑 **Could not read the task list:** {client.sessions_error}"
+            )
+        damaged = sum(1 for r in rows if r[6] != "ok")
+        if damaged:
+            desc_parts.append(
+                f"⚠ **{damaged} damaged episode"
+                f"{'s' if damaged != 1 else ''}** (see the Status column) — "
+                "recording was interrupted, so there is no data to recover. "
+                "Tick the row(s) and press **Delete**."
+            )
         desc = "\n\n".join(desc_parts)
         return rows, move_dd, task_header, desc, cap_title, ep_title
 
@@ -1284,11 +1300,11 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
                 task_desc_md = gr.Markdown("")
 
                 episodes_table = gr.Dataframe(
-                    headers=["✓", "Episode ID", "Duration", "Frames", "IMU", "Angle"],
-                    datatype=["bool", "str", "str", "number", "number", "number"],
+                    headers=["✓", "Episode ID", "Duration", "Frames", "IMU", "Angle", "Status"],
+                    datatype=["bool", "str", "str", "number", "number", "number", "str"],
                     interactive=True,
-                    static_columns=[1, 2, 3, 4, 5],
-                    col_count=(6, "fixed"),
+                    static_columns=[1, 2, 3, 4, 5, 6],
+                    col_count=(7, "fixed"),
                     show_search="filter",
                 )
                 with gr.Row():

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -598,12 +598,15 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
         rows = []
         task_name = ""
         task_description = ""
+        export_skipped = 0
         for s in sessions:
             if s["id"] == session_id:
                 task_name = s.get("name", "")
                 task_description = s.get("description", "")
                 for ep in s.get("episodes", []):
                     issues = ep.get("issues") or []
+                    if "no OAK-D video" in issues:
+                        export_skipped += 1
                     rows.append([
                         False,
                         ep["episode_id"],
@@ -635,14 +638,18 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
             desc_parts.append(
                 f"🛑 **Could not read the task list:** {client.sessions_error}"
             )
-        damaged = sum(1 for r in rows if r[6] != "ok")
-        if damaged:
-            desc_parts.append(
-                f"⚠ **{damaged} damaged episode"
-                f"{'s' if damaged != 1 else ''}** (see the Status column) — "
-                "recording was interrupted, so there is no data to recover. "
-                "Tick the row(s) and press **Delete**."
+        flagged = sum(1 for r in rows if r[6] != "ok")
+        if flagged:
+            msg = (
+                f"⚠ **{flagged} episode{'s' if flagged != 1 else ''} flagged** "
+                "— see the Status column."
             )
+            if export_skipped:
+                msg += (
+                    f" {export_skipped} without OAK-D video will be skipped "
+                    "by the dataset export."
+                )
+            desc_parts.append(msg)
         desc = "\n\n".join(desc_parts)
         return rows, move_dd, task_header, desc, cap_title, ep_title
 

--- a/packages/grabette/tests/test_session.py
+++ b/packages/grabette/tests/test_session.py
@@ -80,3 +80,40 @@ def test_delete_session_purges_episodes(tmp_path):
 
     assert not (tmp_path / "episodes" / "ep_b").exists()
     assert "ep_b" not in sm.get_session_detail(UNASSIGNED_ID).episode_ids
+
+
+def test_corrupt_metadata_does_not_break_listing(tmp_path):
+    # A capture cut short can leave metadata.json empty/truncated. That must
+    # not raise out of list_sessions() — the dashboard reads the whole task
+    # list through it, so one bad episode used to blank every task at once.
+    _make_episode(tmp_path, "ep_ok", ["oakd_imu.json"], meta={"frame_count": 42})
+    _make_episode(tmp_path, "ep_bad", ["oakd_imu.json"])
+    (tmp_path / "episodes" / "ep_bad" / "metadata.json").write_text("")
+
+    sm = SessionManager(data_dir=tmp_path)
+    sm.move_episodes(["ep_ok", "ep_bad"], UNASSIGNED_ID)
+
+    detail = sm.get_session_detail(UNASSIGNED_ID)
+    assert detail.episode_count == 2
+    by_id = {e.episode_id: e for e in detail.episodes}
+    assert by_id["ep_ok"].frame_count == 42
+    assert by_id["ep_bad"].frame_count == 0
+    assert by_id["ep_bad"].has_imu is True
+
+
+def test_active_session_route_not_shadowed():
+    # /api/sessions/active must be declared before /api/sessions/{session_id},
+    # otherwise FastAPI matches "active" as a session id and returns 404.
+    from grabette.app.routers.sessions import router
+
+    order = [
+        (r.path, sorted(r.methods))
+        for r in router.routes
+        if r.path in ("/api/sessions/active", "/api/sessions/{session_id}")
+    ]
+    for method in ("GET", "PUT"):
+        active = next(i for i, (p, m) in enumerate(order)
+                      if p == "/api/sessions/active" and method in m)
+        param = next(i for i, (p, m) in enumerate(order)
+                     if p == "/api/sessions/{session_id}" and method in m)
+        assert active < param, f"{method} /api/sessions/active is shadowed"

--- a/packages/grabette/tests/test_session.py
+++ b/packages/grabette/tests/test_session.py
@@ -117,3 +117,38 @@ def test_active_session_route_not_shadowed():
         param = next(i for i, (p, m) in enumerate(order)
                      if p == "/api/sessions/{session_id}" and method in m)
         assert active < param, f"{method} /api/sessions/active is shadowed"
+
+
+def test_healthy_episode_reports_no_issues(tmp_path):
+    _make_episode(tmp_path, "ep_fine", ["oakd_imu.json", "raw_video.mp4"])
+    info = SessionManager(data_dir=tmp_path)._get_episode_info("ep_fine")
+    assert info.issues == []
+
+
+def test_aborted_capture_is_flagged_not_hidden(tmp_path):
+    # An interrupted capture leaves every output file created but zero-length.
+    # exists() alone reported has_video=True for a 0-byte mp4, so the episode
+    # looked merely "empty" instead of broken.
+    ep = tmp_path / "episodes" / "ep_aborted"
+    ep.mkdir(parents=True)
+    for name in ("raw_video.mp4", "oakd_imu.json", "metadata.json"):
+        (ep / name).write_text("")
+
+    info = SessionManager(data_dir=tmp_path)._get_episode_info("ep_aborted")
+
+    assert info.has_video is False
+    assert info.has_imu is False
+    assert set(info.issues) == {"empty video", "empty IMU log", "unreadable metadata"}
+
+
+def test_truncated_metadata_flagged_but_media_kept(tmp_path):
+    # Only metadata.json is damaged: the media is fine and must stay usable,
+    # so exactly one issue is reported.
+    _make_episode(tmp_path, "ep_meta", ["oakd_imu.json", "raw_video.mp4"])
+    (tmp_path / "episodes" / "ep_meta" / "metadata.json").write_text('{"frame_count": 4')
+
+    info = SessionManager(data_dir=tmp_path)._get_episode_info("ep_meta")
+
+    assert info.issues == ["unreadable metadata"]
+    assert info.has_video is True
+    assert info.has_imu is True

--- a/packages/grabette/tests/test_session.py
+++ b/packages/grabette/tests/test_session.py
@@ -152,3 +152,41 @@ def test_truncated_metadata_flagged_but_media_kept(tmp_path):
     assert info.issues == ["unreadable metadata"]
     assert info.has_video is True
     assert info.has_imu is True
+
+
+def test_dead_oakd_is_flagged(tmp_path):
+    # The OAK-D died mid-capture: the Pi camera and angles recorded fine, so
+    # the episode reports a full frame count and looks healthy — but it has no
+    # oakd_left.mp4 and the SLAM export drops it without a word.
+    _make_episode(
+        tmp_path, "ep_dead_oak",
+        ["raw_video.mp4", "angle_data.json", "oakd_calib.json",
+         "oakd_left.h264", "oakd_right.h264"],
+        meta={"frame_count": 396, "duration_seconds": 8.08},
+    )
+    for name in ("oakd_left.h264", "oakd_right.h264"):
+        (tmp_path / "episodes" / "ep_dead_oak" / name).write_text("")
+
+    info = SessionManager(data_dir=tmp_path)._get_episode_info("ep_dead_oak")
+
+    assert info.frame_count == 396
+    assert info.has_video is True
+    assert set(info.issues) == {
+        "no OAK-D video", "no OAK-D IMU", "unmuxed OAK-D stream",
+    }
+
+
+def test_healthy_oakd_episode_is_clean(tmp_path):
+    _make_episode(
+        tmp_path, "ep_oak_ok",
+        ["raw_video.mp4", "oakd_calib.json", "oakd_left.mp4",
+         "oakd_right.mp4", "oakd_imu.json"],
+    )
+    assert SessionManager(data_dir=tmp_path)._get_episode_info("ep_oak_ok").issues == []
+
+
+def test_legacy_episode_is_not_flagged_for_missing_oakd(tmp_path):
+    # No oakd_calib.json: this recording never had an OAK-D, so the absence of
+    # its outputs is normal, not damage.
+    _make_episode(tmp_path, "ep_legacy_ok", ["raw_video.mp4", "imu_data.json"])
+    assert SessionManager(data_dir=tmp_path)._get_episode_info("ep_legacy_ok").issues == []


### PR DESCRIPTION
The dashboard showed no tasks if there were a corrupted metadata.json (like an empty one). 
Now, the tasks appear, and there is a status column to show if there is an issue with the episode (no metadata, no OAK data, etc.) with an error message at the top of the episode list 