### PR TITLE
Stop the BT tool burying the real connection error

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -257,8 +257,23 @@
         document.getElementById('btnNetStatus').disabled = !connected;
     }
 
+    // Chrome's two wordings for "BlueZ no longer has this device object". A
+    // failed connect makes BlueZ evict the device, so the handle we hold is
+    // dead: only a fresh requestDevice() can replace it, and that needs a new
+    // user gesture. Retrying past this point just buries the real error.
+    function isDeadHandle(e) {
+        return /no longer in range|doesn't exist anymore/i.test(e.message || '');
+    }
+
     async function connectDevice() {
         const targetName = document.getElementById('deviceSelect').value;
+        // Block a second click while the first is still connecting: opening the
+        // chooser again starts a fresh scan, and that scan aborts the
+        // connection already in flight (BlueZ reports
+        // le-connection-abort-by-local), so the extra click breaks the very
+        // attempt it looks like it is helping.
+        const btnConnect = document.getElementById('btnConnect');
+        btnConnect.disabled = true;
         try {
             log('Scanning for ' + targetName + '...');
             // Match by name PREFIX: the device advertises "Grabette (hostname)"
@@ -275,9 +290,12 @@
             });
 
             // GATT can connect then drop immediately (common on Linux/BlueZ),
-            // so retry the connect + service discovery a few times.
+            // so retry the connect + service discovery a few times — but stop
+            // the moment the handle itself is dead, because those retries
+            // cannot succeed and their error replaces the one that explains
+            // what actually went wrong.
             let cmdService;
-            const maxAttempts = 5;
+            const maxAttempts = 3;
             for (let attempt = 1; ; attempt++) {
                 try {
                     log('Connecting GATT (attempt ' + attempt + '/' + maxAttempts + ')...');
@@ -285,7 +303,7 @@
                     cmdService = await server.getPrimaryService(SERVICE_UUID);
                     break;
                 } catch (e) {
-                    if (attempt >= maxAttempts) throw e;
+                    if (attempt >= maxAttempts || isDeadHandle(e)) throw e;
                     log('GATT unstable, retrying: ' + e.message, 'log-err');
                     if (device.gatt.connected) device.gatt.disconnect();
                     await new Promise(r => setTimeout(r, 500));
@@ -313,6 +331,13 @@
             log('Connected to ' + shownName, 'log-ok');
         } catch (e) {
             log('Connection failed: ' + e.message, 'log-err');
+            if (isDeadHandle(e)) {
+                log('The device entry expired — click Connect and pick it again.', 'log-err');
+            }
+        } finally {
+            // setConnected(true) already disabled the button on success; only a
+            // failed attempt needs it back.
+            if (!(device && device.gatt.connected)) btnConnect.disabled = false;
         }
     }
 


### PR DESCRIPTION
Retrying a failed GATT connect cannot work: the failure makes BlueZ evict the device, so the handle is dead and only a fresh requestDevice(), i.e a new user gesture, can replace it. The five attempts therefore ended in four doomed ones whose "Bluetooth Device is no longer in range" overwrote the message that actually explained the failure. Retry only while the handle is live, and say outright that the entry expired.

The Connect button also stayed enabled while connecting, so a second click opened a second chooser whose scan aborted the connection already in flight; disable it for the duration.

Straight to main because the Pages deploy only builds docs/ from here, so the tool stays broken for users until this lands. The Pi-side root cause (a 1.28s advertising interval that made connections time out before the robot saw them) is fixed separately in #122.