### PR TITLE
fix(pipeline): run on bash 3.2, and stop recommending a Hub id for th…

### DIFF
--- a/integrations/DiffusionPolicy/run_pipeline.sh
+++ b/integrations/DiffusionPolicy/run_pipeline.sh
@@ -57,11 +57,10 @@
 #                         how the episodes were actually recorded — see
 #                         docs/grasp_projection_recording_procedure.md.
 #   --projection-repo-id ID
-#                         --grasp-projection: repo_id used to open the converted
-#                         dataset for its (mandatory) stats pass. Defaults to the
-#                         raw input's id. Must RESOLVE on the Hub — LeRobotDataset
-#                         queries revisions even for a local root, so an invented
-#                         id 404s. The data always comes from the local root.
+#                         --grasp-projection: repo_id the converted dataset is
+#                         opened under for its (mandatory) stats pass. Defaults to
+#                         a local id, which needs no Hub access — you should not
+#                         need this flag. The data always comes from the local root.
 #   --no-qa               skip the analyze_dataset.py QA step
 #   --no-resize           skip the 480x360 training copy (train on full res —
 #                         debugging only; costs 2-3x more per training step)
@@ -128,6 +127,10 @@ CLEAN_ROOT="$WORK/clean"
 CART_ROOT="$WORK/cartesian"
 
 # Optional args as arrays (robust to spaces / empty).
+# Expanded as ${A[@]+"${A[@]}"} at every use site, NOT "${A[@]}": bash 3.2 —
+# still the default /bin/bash on macOS — counts an EMPTY array as unset under
+# `set -u` and aborts with 'unbound variable'. Bash >= 4.4 does not. This script
+# has to run on both.
 RAW_ROOT_ARG=();  [[ -n "$RAW_ROOT" ]]     && RAW_ROOT_ARG=(--root "$RAW_ROOT")
 CLEAN_EXTRA=();   [[ -n "$MAX_LOST_RUN" ]] && CLEAN_EXTRA=(--max_lost_run "$MAX_LOST_RUN")
 # Camera filter: keep only the training camera(s) unless --cameras all.
@@ -146,9 +149,9 @@ echo "════════════════════════�
 
 echo; echo "==> [1] clean — reject episodes with unrecoverable SLAM loss"
 uv run python clean_dataset.py \
-  --repo_id "$RAW" "${RAW_ROOT_ARG[@]}" \
+  --repo_id "$RAW" ${RAW_ROOT_ARG[@]+"${RAW_ROOT_ARG[@]}"} \
   --output_repo_id "$CLEAN_ID" --output_root "$CLEAN_ROOT" --overwrite_output \
-  "${CLEAN_EXTRA[@]}"
+  ${CLEAN_EXTRA[@]+"${CLEAN_EXTRA[@]}"}
 
 CONVERT_EXTRA=(); [[ -n "$SMOOTH_POSES" ]] && CONVERT_EXTRA=(--smooth_poses "$SMOOTH_POSES")
 echo; echo "==> [2] convert — camera-local deltas + per-frame despike"
@@ -156,7 +159,7 @@ uv run python convert_dataset.py \
   --repo_id "$CLEAN_ID" --root "$CLEAN_ROOT" \
   --proprioception "$PROPRIO" \
   --output_repo_id "$CART_ID" --output_root "$CART_ROOT" --overwrite_output \
-  "${CONVERT_EXTRA[@]}"
+  ${CONVERT_EXTRA[@]+"${CONVERT_EXTRA[@]}"}
 
 if [[ "$DO_QA" == 1 ]]; then
   echo; echo "==> [3] analyze — QA on the converted dataset"
@@ -207,12 +210,18 @@ if [[ "$DO_PROJECTION" == 1 ]]; then
   PROJ_ID="local/${BASE}_graspproj"
   PROJ_ROOT="$WORK/graspproj"
   PROJ_EXTRA=(); [[ "$REST_IS_CLOSED" == 1 ]] && PROJ_EXTRA=(--rest_is_closed)
-  # The converter's stats pass opens the dataset through LeRobotDataset, which
-  # queries the Hub for revisions even when `root` is local — so the id has to be
-  # one that RESOLVES. An invented `local/..._graspproj` 404s. The raw input's id
-  # is the right one (the data still comes from --dst_root); override with
-  # --projection-repo-id when the raw input is itself local-only.
-  PROJ_REPO_ID="${PROJ_REPO_ID:-$RAW}"
+  # The converter's stats pass opens the dataset through LeRobotDataset. A LOCAL
+  # id is deliberate here, and better than the raw input's id in both directions:
+  #
+  #   - it needs no Hub access. LeRobotDataset only queries the Hub when the root
+  #     is incomplete; against a fully-written root an unknown `local/...` id opens
+  #     fine (measured). That keeps an offline pipeline offline.
+  #   - a REAL Hub id is actively risky. Opening a freshly converted dataset under
+  #     its SOURCE repo's id is what once re-downloaded source parquet over the
+  #     converted files — the conversion silently reverted.
+  #
+  # --projection-repo-id remains as an escape hatch, not a normal requirement.
+  PROJ_REPO_ID="${PROJ_REPO_ID:-$PROJ_ID}"
   echo; echo "==> [7] grasp projection — gripper angles -> (strategy, closure)"
   # Runs in the grabette-postprocess project, not this one: the converter and the
   # projection itself live there (and in gripette), and this uv project carries
@@ -220,10 +229,12 @@ if [[ "$DO_PROJECTION" == 1 ]]; then
   if ! uv run --project ../../packages/grabette-postprocess \
       python -m grabette_postprocess.grasp_projection_convert \
       --src_root "$TRAIN_ROOT" --dst_root "$PROJ_ROOT" --overwrite \
-      --repo_id "$PROJ_REPO_ID" "${PROJ_EXTRA[@]}"; then
+      --repo_id "$PROJ_REPO_ID" ${PROJ_EXTRA[@]+"${PROJ_EXTRA[@]}"}; then
     echo "ERROR: the grasp projection step failed." >&2
-    echo "       If it 404'd on '$PROJ_REPO_ID': the stats pass needs a repo_id that" >&2
-    echo "       resolves on the Hub. Pass --projection-repo-id <a real dataset id>." >&2
+    echo "       The stats pass opened the dataset as '$PROJ_REPO_ID' (local, no Hub" >&2
+    echo "       access). If it failed there, the converted root at" >&2
+    echo "       $PROJ_ROOT is probably incomplete — check the" >&2
+    echo "       converter output above rather than the repo id." >&2
     echo "       Stats are NOT optional here — closure is 0..1 where the raw angle" >&2
     echo "       was 0..1.6 rad, so stale stats mis-normalise the channel." >&2
     exit 1

--- a/packages/grabette-postprocess/grabette_postprocess/grasp_projection_convert.py
+++ b/packages/grabette-postprocess/grabette_postprocess/grasp_projection_convert.py
@@ -380,10 +380,13 @@ def convert_dataset(
                    "meaning and RANGE, so stale stats mis-normalise training.")
 @click.option("--repo_id", default=None,
               help="repo_id to open the converted dataset under, for the stats "
-                   "pass only. LeRobotDataset queries the Hub for available "
-                   "revisions even when `root` is local, so an invented id 404s. "
-                   "Use the SOURCE dataset's id — the data still comes from "
-                   "--dst_root.")
+                   "pass only; the data always comes from --dst_root. A LOCAL id "
+                   "(local/anything) is the right choice and needs no Hub access: "
+                   "LeRobotDataset only queries the Hub when the root is "
+                   "incomplete, and by this point it is fully written. Do NOT pass "
+                   "the SOURCE dataset's Hub id — opening the converted dataset "
+                   "under it has re-downloaded source parquet over the converted "
+                   "files, silently reverting the conversion.")
 def main(src_root, dst_root, rest_is_closed, overwrite, recompute_stats, repo_id):
     """Re-express a dataset's gripper channels as (strategy, commanded closure)."""
     logging.basicConfig(level=logging.INFO, format="%(message)s")


### PR DESCRIPTION
…e stats pass

Two fixes to run_pipeline.sh.

1. Empty arrays under `set -u`. bash 3.2 — still the default /bin/bash on macOS — treats "${EMPTY[@]}" as unbound and aborts:

     run_pipeline.sh: line 148: RAW_ROOT_ARG[@]: unbound variable

   Hit on a Mac by any run that omits --raw-root (a Hub dataset), i.e. the documented common case. Now expanded as ${A[@]+"${A[@]}"}, which is safe on 3.2 and >= 4.4 and preserves arguments containing spaces (verified).

2. --projection-repo-id defaulted to the raw input's Hub id, and its help said the id "must resolve on the Hub". Both wrong: LeRobotDataset only queries the Hub when the root is incomplete, so an unknown local/ id opens a fully-written root fine (measured). Worse, a real SOURCE id is the risky choice — opening a converted dataset under it has re-downloaded source parquet over the converted files, silently reverting the conversion. Default is now the local id; the flag stays as an escape hatch. The converter's own --repo_id help said the same wrong thing and is corrected too.


Claude-Session: https://claude.ai/code/session_0185xfk84D8sCXWMPmx1cxpp