### PR TITLE
rpi: install the BLE and build deps in install-rpi

### DIFF
--- a/packages/gripette/Makefile
+++ b/packages/gripette/Makefile
@@ -33,7 +33,12 @@ help:
 install-rpi: check-hand enable-uart harden-rpi
 	@command -v uv >/dev/null || { echo "Install uv first: https://docs.astral.sh/uv/"; exit 1; }
 	sudo apt update
-	sudo apt install -y python3-libcamera python3-picamera2 libcap-dev
+	@# python3-dbus + python3-gi: the BLE WiFi provisioning service
+	@# (gripette.bluetooth.bluetooth_service) talks to BlueZ over DBus and runs a
+	@# GLib mainloop. Usually preinstalled on Pi OS, but not guaranteed.
+	@# python3-dev: Python.h, for any dependency that still builds from source.
+	sudo apt install -y python3-libcamera python3-picamera2 libcap-dev \
+	  python3-dev python3-dbus python3-gi
 	@# sudo rm: if any service ran as root and left root-owned .pyc files in
 	@# the venv (we fixed this with PYTHONDONTWRITEBYTECODE=1 in the unit
 	@# files, but existing installs may still have leftover root-owned

--- a/packages/gripette/Makefile
+++ b/packages/gripette/Makefile
@@ -33,12 +33,10 @@ help:
 install-rpi: check-hand enable-uart harden-rpi
 	@command -v uv >/dev/null || { echo "Install uv first: https://docs.astral.sh/uv/"; exit 1; }
 	sudo apt update
-	@# python3-dbus + python3-gi: the BLE WiFi provisioning service
-	@# (gripette.bluetooth.bluetooth_service) talks to BlueZ over DBus and runs a
-	@# GLib mainloop. Usually preinstalled on Pi OS, but not guaranteed.
-	@# python3-dev: Python.h, for any dependency that still builds from source.
+	@# python3-dev + libcap-dev: python-prctl and pidng still build from source
+	@# here. python3-dbus/-gi/bluez: the BLE WiFi service (DBus + GLib mainloop).
 	sudo apt install -y python3-libcamera python3-picamera2 libcap-dev \
-	  python3-dev python3-dbus python3-gi
+	  python3-dev python3-dbus python3-gi bluez
 	@# sudo rm: if any service ran as root and left root-owned .pyc files in
 	@# the venv (we fixed this with PYTHONDONTWRITEBYTECODE=1 in the unit
 	@# files, but existing installs may still have leftover root-owned

--- a/packages/gripette/README.md
+++ b/packages/gripette/README.md
@@ -85,10 +85,10 @@ make check                                      # services should now report [OK
 
 `make install-rpi` is idempotent — re-running it is safe (and preserves any captured calibration offsets in `/etc/gripette/env`). Under the hood it:
 
-- installs `python3-libcamera`, `python3-picamera2`, `libcap-dev`, `python3-dev`, `python3-dbus`, `python3-gi` via apt;
+- installs the apt system deps — camera, BLE, and the build headers `python-prctl` needs (the `install-rpi` recipe has the list);
 - runs `make enable-uart` to disable the serial console (`cmdline.txt`) and add `dtoverlay=miniuart-bt` to `config.txt` so the reliable PL011 (`ttyAMA0`) ends up on the GPIO header instead of the mini UART (clock-dependent, unreliable at 1Mbaud);
 - runs `make harden-rpi` for crash safety (persistent journal capped at 5 boots / 50MB, and `fsck.mode=force` so a hard shutdown self-heals on next boot — gripettes mounted on a robot get power-cut at random);
-- creates a `--system-site-packages` venv at the workspace root so apt's `picamera2` satisfies the dependency tree (otherwise `uv` tries to build `python-prctl` from PyPI);
+- creates a `--system-site-packages` venv at the workspace root so apt's `picamera2` satisfies the dependency tree (`python-prctl` and `pidng` still build from source — hence `python3-dev` and `libcap-dev`);
 - runs `uv sync --package gripette --extra rpi --no-install-package numpy` and verifies that `picamera2`, `serial`, and `rustypot` all import;
 - writes `GRIPPER_HAND` into `/etc/gripette/env`, preserving any existing `GRIPPER_MOTOR*_OFFSET` lines from a previous calibration.
 
@@ -99,7 +99,7 @@ make check                                      # services should now report [OK
 If `make install-rpi` fails (e.g. unusual OS), the equivalent manual steps are:
 
 1. **UART**: edit `/boot/firmware/config.txt` to include `dtoverlay=miniuart-bt` and `enable_uart=1`. Edit `/boot/firmware/cmdline.txt` to remove `console=serial0,115200` — keep the file as a single line. Reboot.
-2. **Deps**: `sudo apt install libcap-dev python3-libcamera python3-picamera2 python3-dev python3-dbus python3-gi`.
+2. **Deps**: `sudo apt install libcap-dev python3-libcamera python3-picamera2 python3-dev python3-dbus python3-gi bluez`.
 3. **Venv**: from the workspace root, `uv venv --python /usr/bin/python3 --system-site-packages && uv sync --package gripette --extra rpi --no-install-package numpy`.
 4. **Hand config**: `sudo mkdir -p /etc/gripette && echo "GRIPPER_HAND=right" | sudo tee /etc/gripette/env` (or `=left`).
 

--- a/packages/gripette/README.md
+++ b/packages/gripette/README.md
@@ -85,7 +85,7 @@ make check                                      # services should now report [OK
 
 `make install-rpi` is idempotent — re-running it is safe (and preserves any captured calibration offsets in `/etc/gripette/env`). Under the hood it:
 
-- installs `python3-libcamera`, `python3-picamera2`, `libcap-dev` via apt;
+- installs `python3-libcamera`, `python3-picamera2`, `libcap-dev`, `python3-dev`, `python3-dbus`, `python3-gi` via apt;
 - runs `make enable-uart` to disable the serial console (`cmdline.txt`) and add `dtoverlay=miniuart-bt` to `config.txt` so the reliable PL011 (`ttyAMA0`) ends up on the GPIO header instead of the mini UART (clock-dependent, unreliable at 1Mbaud);
 - runs `make harden-rpi` for crash safety (persistent journal capped at 5 boots / 50MB, and `fsck.mode=force` so a hard shutdown self-heals on next boot — gripettes mounted on a robot get power-cut at random);
 - creates a `--system-site-packages` venv at the workspace root so apt's `picamera2` satisfies the dependency tree (otherwise `uv` tries to build `python-prctl` from PyPI);
@@ -99,7 +99,7 @@ make check                                      # services should now report [OK
 If `make install-rpi` fails (e.g. unusual OS), the equivalent manual steps are:
 
 1. **UART**: edit `/boot/firmware/config.txt` to include `dtoverlay=miniuart-bt` and `enable_uart=1`. Edit `/boot/firmware/cmdline.txt` to remove `console=serial0,115200` — keep the file as a single line. Reboot.
-2. **Deps**: `sudo apt install libcap-dev python3-libcamera python3-picamera2`.
+2. **Deps**: `sudo apt install libcap-dev python3-libcamera python3-picamera2 python3-dev python3-dbus python3-gi`.
 3. **Venv**: from the workspace root, `uv venv --python /usr/bin/python3 --system-site-packages && uv sync --package gripette --extra rpi --no-install-package numpy`.
 4. **Hand config**: `sudo mkdir -p /etc/gripette && echo "GRIPPER_HAND=right" | sudo tee /etc/gripette/env` (or `=left`).
 

--- a/packages/gripette/docs/bluetooth_setup.md
+++ b/packages/gripette/docs/bluetooth_setup.md
@@ -13,7 +13,7 @@ The gripette (Pi Zero 2W) is enclosed in the gripper with no physical access. A 
 
 ### 1. Install system dependencies
 
-These are usually pre-installed on Raspberry Pi OS:
+Already installed by `make install-rpi`. If you skipped it, or they were removed:
 
 ```bash
 sudo apt install python3-dbus python3-gi bluez


### PR DESCRIPTION
Closes #138.

`install-rpi` is the one-shot bring-up, but its apt line stopped at the camera deps. Adds the three that were missing:

- **`python3-dbus`**, **`python3-gi`** — `gripette.bluetooth.bluetooth_service` does `import dbus` / `dbus.service` / `dbus.mainloop.glib` and `from gi.repository import GLib`. They were only documented as a separate manual step in `docs/bluetooth_setup.md`.
- **`python3-dev`** — `Python.h`, for any dependency that still builds from source. On a fresh trixie install it was present only as an *auto*-installed transitive dep, so `apt autoremove` can take it away. Naming it here marks it manual.

The split defeated the point of the BLE service: a gripette sealed inside the gripper has no physical access, and provisioning it over Bluetooth required SSH'ing in first to install the deps it needs to advertise.

Also updates the README (both the "under the hood" list and the manual-installation fallback), and drops the now-wrong "usually pre-installed" line in `bluetooth_setup.md`.

### Testing

`make --dry-run install-rpi HAND=right` — line-continuation renders as one command:

```
sudo apt install -y python3-libcamera python3-picamera2 libcap-dev \
  python3-dev python3-dbus python3-gi
```

Same line dry-run on a real gripette (`r-gripette.local`, Debian 13 trixie) — every name resolves, and it's a no-op on an already-installed Pi, so `install-rpi` stays idempotent:

```
Summary:
  Upgrading: 0, Installing: 0, Removing: 0, Not Upgrading: 68
```

Not verified: a from-scratch `install-rpi` on a blank SD card.
