### PR TITLE
openarm_gripette_simu: resize eval frames to the checkpoint's training resolution

### DIFF
--- a/integrations/openarm/openarm_gripette_simu/examples/evaluate.py
+++ b/integrations/openarm/openarm_gripette_simu/examples/evaluate.py
@@ -54,6 +54,14 @@ def _load_policy_any(checkpoint: str):
     if cfg.type in ("pi05", "pi0"):
         policy = policy.to(dtype=torch.float32)
     return policy
+
+
+def _policy_img_hw(policy):
+    """(H, W) the checkpoint was trained on. ACT has no internal resize
+    (diffusion/pi0 do), so live frames must be brought to this size."""
+    for ft in policy.config.image_features.values():
+        return int(ft.shape[1]), int(ft.shape[2])
+    return None
 from scipy.spatial.transform import Rotation
 from openarm_gripette_simu.rotation import (
     rotation_6d_to_matrix as rotation_6d_to_rotation_matrix_numpy,
@@ -1117,6 +1125,9 @@ def run_episode(
     if dump_dir is not None:
         dump_dir = _Path(dump_dir)
         dump_dir.mkdir(parents=True, exist_ok=True)
+    # Training resolution for local inference (remote mode resizes to the
+    # server-advertised remote_img_wh in its own branch below).
+    img_hw = _policy_img_hw(policy) if client is None else None
     # Latency bookkeeping. frame_ts is the SERVER's monotonic clock, so an
     # absolute frame→local age is unknowable; instead track (a) inter-frame
     # timestamp deltas = true camera rate + stale-duplicate detection, and
@@ -1163,6 +1174,11 @@ def run_episode(
         frame_staleness = (recv_ms - frame_ts_ms) - lat_min_offset
         frame_dts = (frame_ts_ms - lat_prev_ts) if lat_prev_ts is not None else None
         lat_prev_ts = frame_ts_ms
+
+        # Resize to training res BEFORE the dump so it stays the exact policy input.
+        if img_hw is not None and camera_image.shape[:2] != img_hw:
+            camera_image = cv2.resize(camera_image, img_hw[::-1],
+                                      interpolation=cv2.INTER_AREA)
 
         # Dump the exact observation fed to the policy (pre-normalization), for
         # offline train/deploy distribution checks (DiffusionPolicy/ood_check.py).
@@ -1601,6 +1617,7 @@ def run_episode_async(
     if dump_dir is not None:
         dump_dir = _Path(dump_dir)
         dump_dir.mkdir(parents=True, exist_ok=True)
+    img_hw = _policy_img_hw(policy)  # training resolution, see _policy_img_hw
 
     def make_batch(img, grip):
         state = torch.from_numpy(np.asarray(grip, dtype=np.float32))
@@ -1630,6 +1647,9 @@ def run_episode_async(
     try:
         while executor.sent_count < max_steps and executor.frozen is None:
             (img_prev, grip_prev, _ts_prev), (img_now, grip_now, ts_now) = camera.get_pair()
+            if img_hw is not None and img_now.shape[:2] != img_hw:
+                img_prev = cv2.resize(img_prev, img_hw[::-1], interpolation=cv2.INTER_AREA)
+                img_now = cv2.resize(img_now, img_hw[::-1], interpolation=cv2.INTER_AREA)
             sent_at_obs = executor.sent_count
             recv_ms = time.perf_counter() * 1000.0
             lat_min_offset = min(lat_min_offset, recv_ms - ts_now)

--- a/integrations/openarm/openarm_gripette_simu/pyproject.toml
+++ b/integrations/openarm/openarm_gripette_simu/pyproject.toml
@@ -22,10 +22,12 @@ dataset = ["lerobot[dataset]==0.6.0 ; python_version >= '3.12'"]
 # Policy evaluation client (examples/evaluate.py): loads a trained policy and
 # drives the sim over gRPC. [diffusion] supplies diffusers; [pi] supplies the
 # transformers stack for the Pi0/Pi0.5/Pi0Fast checkpoints this client supports.
-# scipy is also used directly for rotation math.
+# scipy is also used directly for rotation math; gripette supplies
+# grasp_projection (state/action encoding for projected checkpoints).
 eval = [
     "lerobot[diffusion,pi]==0.6.0 ; python_version >= '3.12'",
     "scipy>=1.10",
+    "gripette",
 ]
 # tests/ — needs the `eval` extra as well: the GripAssist regression tests load
 # examples/evaluate.py, which imports the policy stack.
@@ -39,6 +41,7 @@ build-backend = "hatchling.build"
 # Resolved from the monorepo workspace (integrations/openarm/openarm_gripette_model),
 # not PyPI. Was a local `../` path dep in the standalone repo.
 openarm-gripette-model = { workspace = true }
+gripette = { workspace = true }
 
 # OpenCV is intentionally headless by default: lerobot depends on
 # opencv-python-headless and the on-device services (grabette/Pi) need it, and

--- a/uv.lock
+++ b/uv.lock
@@ -3056,6 +3056,7 @@ dev = [
     { name = "grpcio-tools" },
 ]
 eval = [
+    { name = "gripette" },
     { name = "lerobot", extra = ["diffusion", "pi"], marker = "python_full_version >= '3.12'" },
     { name = "scipy" },
 ]
@@ -3065,6 +3066,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gripette", marker = "extra == 'eval'", editable = "packages/gripette" },
     { name = "grpcio", specifier = ">=1.81" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.60" },
     { name = "lerobot", extras = ["dataset"], marker = "python_full_version >= '3.12' and extra == 'dataset'", specifier = "==0.6.0" },


### PR DESCRIPTION
Fixes #143

## What

Two fixes to `examples/evaluate.py` local inference, found while evaluating `CarolinePascal/act-sugar-cup-cartesian-ep0-66` (trained on the 480x360 `_cartesian_480` dataset) against the sim's 960x720 camera:

1. **Resize live frames to the checkpoint's training resolution.** New `_policy_img_hw()` reads the expected (H, W) from the checkpoint's `config.image_features` (no hardcoded size — checkpoints trained at other resolutions keep working), and both the sync (`run_episode`) and async (`run_episode_async`) paths do a guarded `cv2.resize(..., INTER_AREA)` right after frame acquisition. Placed **before** the `--dump_obs` write, so dumps remain "the exact observation fed to the policy" (and PNGs get ~4x cheaper).

2. **Declare `gripette` in the `eval` extra** (workspace source, same wiring as `openarm-gripette-model`). `evaluate.py` imports `gripette.grasp_projection` at top level; a fresh venv failed with `ModuleNotFoundError`.

## Why ACT only

ACT has no internal resize (lerobot 0.6.0: preprocessor is rename → batch → device → normalize, nothing else), unlike diffusion (`Resize`+`CenterCrop`) and pi0 (`resize_with_pad_torch`). For those the pre-resize is a harmless no-op-equivalent that matches training even more exactly. Plain resize is correct — no crop — since 960x720 and 480x360 are both 4:3 (the `_480` dataset is an exact /2 downscale of the raw recording).

## Verification

- `evaluate.py --help` loads through all top-level imports in a fresh `uv run --extra eval` venv; `gripette.grasp_projection` imports.
- Standalone check against the Hub config confirms `_policy_img_hw` resolves this checkpoint to (360, 480).
- Live run: `--dump_obs` frames should now be 480x360 — needs the robot/sim, please confirm behavior on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)