### PR TITLE
docs: the oak-vslam image is published — pull it

### DIFF
--- a/packages/grabette-postprocess/README.md
+++ b/packages/grabette-postprocess/README.md
@@ -49,7 +49,14 @@ require Python >= 3.12 because that is LeRobot 0.6's minimum.
 uv sync --package grabette-postprocess
 ```
 
-The OAK SLAM step requires Docker with a locally built image:
+The OAK SLAM step requires Docker. The image is published, so pull it:
+
+```bash
+docker pull pollenrobotics/oak-vslam
+```
+
+Pin `:2026-07-22` instead of `:latest` when a result has to stay comparable.
+To build it yourself (Dockerfile + `offline_vslam.cpp` are both in the repo):
 
 ```bash
 docker build -t pollenrobotics/oak-vslam docker/oak_vslam/

--- a/packages/grabette-postprocess/grabette_postprocess/oak_slam.py
+++ b/packages/grabette-postprocess/grabette_postprocess/oak_slam.py
@@ -194,7 +194,9 @@ def run_oak_slam(
     trajectory format (frame_idx, timestamp, state, is_lost, is_keyframe,
     x, y, z, q_x, q_y, q_z, q_w).
 
-    By default the binary runs in Docker; the image must be built once with:
+    By default the binary runs in Docker. The image is published:
+        docker pull pollenrobotics/oak-vslam
+    or build it locally with:
         docker build -t pollenrobotics/oak-vslam docker/oak_vslam/
 
     Args:

--- a/packages/grabette-postprocess/scripts/pipeline/run_oak_slam.py
+++ b/packages/grabette-postprocess/scripts/pipeline/run_oak_slam.py
@@ -22,7 +22,9 @@ def main(input_dir, docker_image, output_csv):
     calib_offline.json, timestamps.csv, imu_acc.csv, imu_gyro.csv,
     frames/*.png, depth/*.png
 
-    Build the Docker image once with:
+    By default the binary runs in Docker. The image is published:
+        docker pull pollenrobotics/oak-vslam
+    or build it locally with:
         docker build -t pollenrobotics/oak-vslam docker/oak_vslam/
 
     Produces <episode_dir>/camera_trajectory.csv (absolute poses) compatible


### PR DESCRIPTION
pollenrobotics/oak-vslam is now on Docker Hub (public), tags `latest` and `2026-07-22`, both sha256:3fd1c9aa5aef. Until now the docs told everyone to build RTAB-Map from source, which is a steep first step for anyone outside the team — and the V1 image being published as pollenrobotics/orbslam3-headless made the V2 one look available when it was not.

Pull is now the documented path in the package README and in both docstrings that mentioned building; the build instructions stay as the fallback.


Claude-Session: https://claude.ai/code/session_0185xfk84D8sCXWMPmx1cxpp