### PR TITLE
Fix silent errors on upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,14 @@ jobs:
         # relay_client imports aiohttp at module level. The alternative, putting a
         # runtime library in the `test` extra, would blur what that extra means:
         # test tooling, installed on top of the feature set under test.
-        run: uv run --package grabette --extra test --extra hf pytest packages/grabette/tests -q
+        #
+        # --extra vision installs opencv-python-headless for the same reason:
+        # grabette.hardware.oakd imports cv2 at module level, so without it
+        # test_hardware_error.py cannot even be COLLECTED — and a collection
+        # error fails the whole run, not just that file. It lives in its own
+        # extra rather than in `rpi`, which is unusable off a Pi (picamera2,
+        # depthai, gpiod) and so can never be installed here.
+        run: uv run --package grabette --extra test --extra hf --extra vision pytest packages/grabette/tests -q
 
       - name: Postprocess unit tests
         # Trajectory math + SLAM-quality / recording checks + episode tags.

--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -17,6 +17,7 @@ from fastapi.staticfiles import StaticFiles
 
 from grabette.config import settings
 from grabette.daemon import Daemon
+from grabette.errors import exc_text as _exc_text
 
 # Route Gradio's internal file cache to the SD card. Gradio copies every
 # callback-returned file path into its cache dir (defaulting to
@@ -182,16 +183,6 @@ class _CommandCancelled(Exception):
     """The operator cancelled this command while it waited on something."""
 
 
-def _exc_text(e: BaseException) -> str:
-    """Never-empty description of an exception.
-
-    `str(asyncio.TimeoutError())` is the EMPTY STRING, so interpolating an
-    exception straight into a message can report only "processing failed:" —
-    leaving the operator nothing to act on, and the failure that says the least is
-    the most common one. Fall back to the class name, which at least names the
-    failure mode.
-    """
-    return str(e).strip() or type(e).__name__
 
 
 def _space_stage(space_repo: str, token: str | None) -> str | None:

--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 import os
+import threading
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -99,6 +101,66 @@ _SPACE_WAKE_PROBE_TIMEOUT_S = 20.0  # one liveness probe
 _SPACE_WAKE_RETRY_S = 5.0           # between probes
 _SPACE_POST_TIMEOUT_S = 120.0       # /api/process, on a Space known to be awake
 _SPACE_POLL_TIMEOUT_S = 30.0        # one /api/status poll (retried on failure)
+
+# --- episode upload (raw dataset) ---------------------------------------------
+# Three layers, because each catches what the one below it cannot:
+#
+# 1. SOCKET timeouts on the Hub client (grabette.hf.install_hub_timeouts). This
+#    is the real cure: huggingface_hub ships its httpx client with timeout=None,
+#    so a link that DEGRADES rather than drops leaves upload_folder waiting on a
+#    socket that never delivers — forever, inside a thread nothing can interrupt.
+#    With per-operation timeouts a stall raises inside the worker, hf_hub retries
+#    it, and the thread DIES. Nothing is left behind.
+# 2. Retry with backoff here, so one bad minute doesn't sink a build that other
+#    devices already spent twenty minutes uploading for.
+# 3. _UPLOAD_ATTEMPT_TIMEOUT_S as a last-resort bound, for a hang no socket
+#    timeout can see (a wedged filesystem, a future hf_hub that ignores the
+#    client factory). It lets the COMMAND report back — the fleet frees the
+#    device — but the worker thread cannot be killed, so it runs on.
+#
+# Which is why uploads get their OWN executor. asyncio.to_thread uses the DEFAULT
+# one, shared with the daemon's 50 Hz sensor poll, the OAK-D bring-up and
+# stop_recording's mux — on a 4-core Pi that pool is 8 threads wide. An abandoned
+# upload burning one of them competes for CPU with the H.264 encoders and the
+# OAK-D drainers during a recording (hf_xet hashes and chunks in native threads),
+# and enough of them would starve the capture path itself. Trading frame
+# stability for upload robustness is not a trade worth making, so the two never
+# share a pool: a stalled upload can only ever degrade uploading.
+_UPLOAD_ATTEMPT_TIMEOUT_S = 1800.0  # last-resort bound on ONE episode's attempt
+_UPLOAD_MAX_ATTEMPTS = 3
+_UPLOAD_RETRY_BASE_S = 5.0          # backoff: 5s, 10s (doubling per attempt)
+# Deliberately narrow: uploads are sequential within a command, so one worker
+# does the work and the second is headroom for a single abandoned thread.
+_UPLOAD_WORKERS = 2
+
+_upload_executor: "concurrent.futures.ThreadPoolExecutor | None" = None
+_upload_executor_lock = threading.Lock()
+# Threads we stopped waiting on that are still running. Self-correcting: each is
+# counted down by its future's done callback if it ever finishes. Incremented on
+# the event loop and decremented in a worker thread, hence the lock.
+_stalled_uploads = 0
+_stall_lock = threading.Lock()
+
+
+def _mark_stalled(delta: int) -> int:
+    """Adjust the stalled-upload count under the lock; returns the new value."""
+    global _stalled_uploads
+    with _stall_lock:
+        _stalled_uploads = max(0, _stalled_uploads + delta)
+        return _stalled_uploads
+
+
+def _get_upload_executor():
+    """The upload-only thread pool, created on first use.
+
+    Lazily, not at import: a device that never runs a fleet dataset build should
+    not carry the threads."""
+    global _upload_executor
+    with _upload_executor_lock:
+        if _upload_executor is None:
+            _upload_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=_UPLOAD_WORKERS, thread_name_prefix="hf-upload")
+    return _upload_executor
 
 # Probing the app is the authoritative readiness test, but it cannot tell apart
 # "still booting" from two states it will never get out of. When the fleet also
@@ -240,7 +302,209 @@ async def _wake_space(session, space_url: str, headers: dict,
             f"Open it once in a browser, then retry.")
 
 
+def _space_quality_summary(quality) -> str:
+    """Why the Space rejected episodes, as one line ("" when it says nothing).
+
+    The Space returns per-episode quality data — the actual reasons, e.g.
+    "missing oakd_calib_offline.json" — and this used to be dropped on the floor
+    here, so a conversion that produced nothing reached the operator as either
+    silence or a bare "processing failed". Reasons are counted rather than
+    listed: twenty episodes failing the same way is one fact, not twenty.
+    """
+    if not isinstance(quality, list):
+        return ""
+    counts: dict[str, int] = {}
+    for ep in quality:
+        if not isinstance(ep, dict):
+            continue
+        for reason in (ep.get("errors") or []):
+            key = str(reason).strip()
+            if key:
+                counts[key] = counts.get(key, 0) + 1
+    if not counts:
+        return ""
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:3]
+    return "; ".join(f"{reason} ({n} episode(s))" for reason, n in ranked)
+
+
+async def _upload_one_episode(hf, ep_dir, raw_repo: str, dest: str, private: bool,
+                              is_cancelled) -> None:
+    """Upload one episode dir, bounded and retried. Raises on final failure.
+
+    Two distinct failures are handled here, and conflating them is what made a
+    flaky link fatal:
+      • a transient error (reset connection, 5xx, stalled socket) — retried with
+        a doubling backoff, because the alternative is losing every OTHER
+        device's completed upload to one bad minute. Re-uploading the same folder
+        is safe: an identical commit is a no-op on the Hub.
+      • an attempt that never returns at all — bounded by
+        _UPLOAD_ATTEMPT_TIMEOUT_S so the COMMAND can report back and the fleet
+        can free this device. The worker thread cannot be killed (upload_folder
+        is not interruptible), so it keeps running; it does so on the upload-only
+        executor, where it can never delay a recording. See _UPLOAD_WORKERS.
+
+    Runs on _get_upload_executor(), never asyncio.to_thread: to_thread means the
+    DEFAULT executor, which the 50 Hz sensor poll and the OAK-D bring-up also use.
+
+    Raises _CommandCancelled the moment the build is cancelled, including during
+    a backoff wait: a cancel must not have to sit out a retry delay.
+    """
+    last: Exception | None = None
+    for attempt in range(1, _UPLOAD_MAX_ATTEMPTS + 1):
+        if is_cancelled():
+            raise _CommandCancelled
+        # Every worker tied up by a previous stall means this attempt would just
+        # queue behind it — silently, for as long as the stall lasts. Say so
+        # instead: it is a device-level fault with a device-level fix.
+        if _stalled_uploads >= _UPLOAD_WORKERS:
+            raise RuntimeError(
+                f"{_stalled_uploads} earlier upload(s) are still stalled on this "
+                "device and cannot be interrupted — reboot it before retrying")
+        # submit() rather than loop.run_in_executor() so we keep the
+        # concurrent.futures future: its done callback runs in the WORKER thread,
+        # independent of the event loop. An asyncio future's callback is
+        # scheduled ON the loop, so a loop that stops before the thread finishes
+        # would leak the stall count permanently.
+        cf = _get_upload_executor().submit(
+            hf.upload_episode, ep_dir, raw_repo, None, dest, private)
+        try:
+            # Shielded: on timeout we must NOT wait for a cancellation the thread
+            # cannot honour — wait_for would otherwise block until it returned,
+            # which is the very hang we are bounding.
+            await asyncio.wait_for(asyncio.shield(asyncio.wrap_future(cf)),
+                                   timeout=_UPLOAD_ATTEMPT_TIMEOUT_S)
+            return
+        except asyncio.TimeoutError as e:
+            last = e
+            # Count the stall BEFORE registering the release, never after: a
+            # thread that finishes in between would fire the callback first
+            # (clamped to 0) and the increment would then leak a phantom stall
+            # forever. add_done_callback on an already-finished future runs
+            # inline, so the window is real, not theoretical.
+            stalled = _mark_stalled(1)
+            cf.add_done_callback(lambda _f: _mark_stalled(-1))
+            logger.error("upload of %s did not return after %.0fs — abandoning the "
+                         "thread (attempt %d/%d, %d now stalled)", dest,
+                         _UPLOAD_ATTEMPT_TIMEOUT_S, attempt, _UPLOAD_MAX_ATTEMPTS,
+                         stalled)
+        except Exception as e:  # noqa: BLE001 — retry whatever the Hub/network raised
+            last = e
+            logger.warning("upload of %s failed (attempt %d/%d): %s",
+                           dest, attempt, _UPLOAD_MAX_ATTEMPTS, _exc_text(e))
+        if attempt < _UPLOAD_MAX_ATTEMPTS:
+            delay = _UPLOAD_RETRY_BASE_S * (2 ** (attempt - 1))
+            # Sleep in slices so a cancel lands within a second, not after the
+            # whole backoff.
+            waited = 0.0
+            while waited < delay:
+                if is_cancelled():
+                    raise _CommandCancelled
+                await asyncio.sleep(min(1.0, delay - waited))
+                waited += 1.0
+    raise RuntimeError(
+        f"{_UPLOAD_MAX_ATTEMPTS} attempts failed, last: {_exc_text(last)}"
+        if last is not None else f"{_UPLOAD_MAX_ATTEMPTS} attempts failed")
+
+
+# Relay commands that make this device too busy to record, and what to call the
+# state. The fleet infers these from its own command queue, but the DEVICE could
+# not see them at all: a relay command creates no local job, so the heartbeat
+# reported "idle" all the way through a 20-minute upload. That blind spot is why
+# the physical button could start a recording on top of one.
+_DATASET_WORK_KINDS = {"upload_episodes": "uploading", "process_dataset": "processing"}
+
+# command id -> kind, for the commands currently executing. The relay's worker is
+# serial so this holds one entry at a time, but it is keyed by id rather than a
+# flag so a lost entry can never wedge the device as permanently busy.
+_active_dataset_work: dict[str, str] = {}
+
+
 async def _handle_relay_command(cmd: dict) -> dict:
+    """Relay entry point: record what this device is busy with, then dispatch.
+
+    Tracked HERE rather than inside each handler so the bookkeeping cannot drift
+    from the dispatch: every command type that occupies the device is declared in
+    one table, and the finally covers every early return in the handlers below.
+    """
+    kind = _DATASET_WORK_KINDS.get(cmd.get("type") or "")
+    if kind is None:
+        return await _dispatch_relay_command(cmd)
+    cmd_id = cmd.get("id") or ""
+    _active_dataset_work[cmd_id] = kind
+    try:
+        return await _dispatch_relay_command(cmd)
+    finally:
+        _active_dataset_work.pop(cmd_id, None)
+
+
+def _device_activity() -> str:
+    """What this device is doing: idle | capturing | uploading | processing.
+
+    ONE answer, used by both consumers: the fleet heartbeat (so an operator sees
+    the true state) and the local capture gate (so a recording can't start on top
+    of it). Two sources that could disagree is how a device ends up called free
+    by one and busy by the other.
+
+    Best-effort and non-throwing — a bad read reports 'idle'. All in-memory, so
+    it stays cheap on the heartbeat.
+    """
+    from grabette.daemon import DaemonState
+    from grabette.jobs import JobStatus, get_job_manager
+
+    # Fleet-dispatched dataset work. First because it is the heaviest and the
+    # least visible: it creates no local job, so nothing else here would see it.
+    kinds = set(_active_dataset_work.values())
+    if "processing" in kinds:
+        return "processing"
+    if "uploading" in kinds:
+        return "uploading"
+    # An upload we stopped waiting on is still RUNNING (see _upload_one_episode):
+    # the thread cannot be killed, and on a Pi it is hashing and chunking, not
+    # idling on a socket. The device is not free just because we gave up on it.
+    if _stalled_uploads:
+        return "uploading"
+    try:
+        active = [j for j in get_job_manager().list_jobs()
+                  if j.status in (JobStatus.PENDING, JobStatus.RUNNING)]
+        if any(j.name.startswith("push:") for j in active):
+            return "processing"  # SLAM convert + push to the dataset
+        if any(j.name.startswith("upload:") for j in active):
+            return "uploading"
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        d = get_daemon_instance()
+        if d is not None and d.state == DaemonState.RUNNING and d.backend.is_capturing:
+            return "capturing"
+    except Exception:  # noqa: BLE001
+        pass
+    return "idle"
+
+
+# Activities during which starting a recording would produce a degraded episode.
+# Mirrors the fleet's _RECORDING_BLOCKERS — the two gates must agree, or the
+# fleet refuses a start the device would have accepted (or worse, the reverse).
+_RECORDING_BLOCKERS = {
+    "uploading": "this grabette is uploading episodes to the Hub — recording now "
+                 "would compete with it for CPU and drop frames. Wait for the "
+                 "upload to finish, or cancel the dataset build.",
+    "processing": "this grabette is running a dataset conversion — recording now "
+                  "would compete with it for CPU and drop frames. Wait for it to "
+                  "finish, or cancel the dataset build.",
+}
+
+
+def _busy_reason() -> str:
+    """Why capture is refused right now for BUSY reasons ("" = free).
+
+    Installed on the backend at startup (set_busy_probe) so every start path —
+    button, dashboard, fleet — goes through it. 'capturing' is deliberately NOT
+    a blocker here: start_capture has its own "Already capturing" error, and
+    reporting it as busy would mask that clearer message."""
+    return _RECORDING_BLOCKERS.get(_device_activity(), "")
+
+
+async def _dispatch_relay_command(cmd: dict) -> dict:
     """Map fleet commands to grabette daemon actions.
 
     start_capture/stop_capture share their scheduling state machine (see
@@ -309,38 +573,87 @@ async def _handle_relay_command(cmd: dict) -> dict:
         private = bool(args.get("private", False))
         if not raw_repo or not role:
             return {"status": "error", "message": "raw_repo and role are required"}
+        from grabette.episode_check import missing_files
+
         tm = get_task_manager()
         hf = get_hf_client()
         uploaded, missing = [], []
+        # Episodes present on disk but lacking a required artifact. Uploading one
+        # is pure waste: the Space rejects it, and in a bimanual build one arm
+        # short drops the WHOLE recording. Screening them here costs a stat() per
+        # file and turns "the dataset came out empty" into a named reason, per
+        # episode, attached to this device.
+        incomplete: list[dict] = []
+        present = []
         for eid in episode_ids:
+            ep_dir = tm.episode_dir(eid)
+            if not ep_dir.exists():
+                missing.append(eid)
+                continue
+            lacks = missing_files(ep_dir)
+            if lacks:
+                incomplete.append({"episode_id": eid, "missing": lacks})
+                continue
+            present.append((eid, ep_dir))
+
+        def _incomplete_summary() -> str:
+            """One line naming what is wrong and how often — the operator needs
+            the failing FILE, not a count of failing episodes."""
+            counts: dict[str, int] = {}
+            for item in incomplete:
+                for name in item["missing"]:
+                    counts[name] = counts.get(name, 0) + 1
+            return ", ".join(f"{name} ({n})" for name, n in
+                             sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+
+        # Nothing left to send: fail NOW instead of uploading zero episodes and
+        # letting the build discover it has nothing to convert half an hour later,
+        # after every other device has finished pushing.
+        if not present and incomplete:
+            return {"status": "error", "role": role,
+                    "message": (f"none of this device's {len(incomplete)} episode(s) can be "
+                                f"converted — {_incomplete_summary()}"),
+                    "uploaded": uploaded, "missing": missing, "incomplete": incomplete}
+
+        for eid, ep_dir in present:
             # Cancellation checkpoint, once per episode. Checked BEFORE the first
             # upload too: the cancel may have landed while this command was still
             # queued behind another one (the relay's worker is serial), in which
             # case nothing should be uploaded at all. Per-episode is the finest
             # granularity available — one episode is a single blocking
             # api.upload_folder inside hf.upload_episode, which cannot be
-            # interrupted from outside.
+            # interrupted from outside (see _upload_one_episode for the bound we
+            # put on it).
             if cancels.is_cancelled(cmd_id):
-                return {"status": "cancelled", "role": role,
-                        "uploaded": uploaded, "missing": missing}
-            ep_dir = tm.episode_dir(eid)
-            if not ep_dir.exists():
-                missing.append(eid)
-                continue
+                return {"status": "cancelled", "role": role, "uploaded": uploaded,
+                        "missing": missing, "incomplete": incomplete}
             try:
-                await asyncio.to_thread(hf.upload_episode, ep_dir, raw_repo, None, f"{eid}/{role}", private)
+                await _upload_one_episode(hf, ep_dir, raw_repo, f"{eid}/{role}", private,
+                                          lambda: cancels.is_cancelled(cmd_id))
                 uploaded.append(eid)
+            except _CommandCancelled:
+                return {"status": "cancelled", "role": role, "uploaded": uploaded,
+                        "missing": missing, "incomplete": incomplete}
             except Exception as e:  # noqa: BLE001
                 if cancels.is_cancelled(cmd_id):
                     # Cancelled mid-upload: the failure is a consequence, not news.
-                    return {"status": "cancelled", "role": role,
-                            "uploaded": uploaded, "missing": missing}
+                    return {"status": "cancelled", "role": role, "uploaded": uploaded,
+                            "missing": missing, "incomplete": incomplete}
                 return {"status": "error", "message": f"upload failed for {eid}: {_exc_text(e)}",
-                        "uploaded": uploaded, "missing": missing, "role": role}
+                        "uploaded": uploaded, "missing": missing,
+                        "incomplete": incomplete, "role": role}
         if cancels.is_cancelled(cmd_id):
-            return {"status": "cancelled", "role": role,
-                    "uploaded": uploaded, "missing": missing}
-        return {"status": "ok", "role": role, "uploaded": uploaded, "missing": missing}
+            return {"status": "cancelled", "role": role, "uploaded": uploaded,
+                    "missing": missing, "incomplete": incomplete}
+        # Succeeded, but say what was left behind: a build quietly assembled from
+        # 17 of 20 episodes is worse than one that says which 3 are gone and why.
+        res = {"status": "ok", "role": role, "uploaded": uploaded,
+               "missing": missing, "incomplete": incomplete}
+        if incomplete:
+            res["message"] = (f"uploaded {len(uploaded)} episode(s); skipped "
+                              f"{len(incomplete)} that cannot be converted — "
+                              f"{_incomplete_summary()}")
+        return res
 
     if ctype == "process_dataset":
         # Fleet-orchestrated dataset build, processing step. THIS device triggers
@@ -423,16 +736,38 @@ async def _handle_relay_command(cmd: dict) -> dict:
                         continue
                     sstatus = st.get("status", "running")
                     if sstatus == "done":
-                        return {"status": "ok", "result_url": st.get("result")}
+                        result_url = st.get("result")
+                        why = _space_quality_summary(st.get("quality"))
+                        if not result_url:
+                            # "done" with no dataset is NOT a success. The Space
+                            # finishes this way when every episode was rejected
+                            # (bad recording check, no usable trajectory) — it
+                            # logs the reason and pushes nothing. Reported as ok,
+                            # it became a fleet job that invented a link to a repo
+                            # that was never created, so the operator got a green
+                            # "Open <dataset>" leading to a 404. Fail it here, and
+                            # carry the Space's own reasons across.
+                            return {"status": "error", "message": (
+                                "the conversion produced no dataset — no episode "
+                                "made it through" + (f": {why}" if why else
+                                                     " (see the Space log for details)"))}
+                        res = {"status": "ok", "result_url": result_url}
+                        # Succeeded, but some episodes may still have been
+                        # dropped; pass the reasons up so the build can say so.
+                        if why:
+                            res["message"] = f"some episodes were excluded: {why}"
+                        return res
                     if sstatus in ("error", "not_found"):
                         # not_found = the Space forgot the job. Its job list lives in
                         # memory, so this means it restarted mid-conversion (OOM, a
                         # redeploy) — say so, rather than echoing "not_found".
                         lost = (f"the Space no longer knows job {space_jid} — it restarted "
                                 f"mid-conversion (its job list is kept in memory)")
+                        why = _space_quality_summary(st.get("quality"))
+                        detail = st.get("error") or (
+                            lost if sstatus == "not_found" else "the Space reported a failure")
                         return {"status": "error",
-                                "message": st.get("error") or (
-                                    lost if sstatus == "not_found" else "the Space reported a failure")}
+                                "message": f"{detail} — {why}" if why else detail}
         except _CommandCancelled:
             return {"status": "cancelled"}
         except Exception as e:  # noqa: BLE001
@@ -650,6 +985,12 @@ async def lifespan(app: FastAPI):
 
     backend = _create_backend()
     _daemon = Daemon(backend)
+    # The capture gate: every start path (button, dashboard, fleet) goes through
+    # backend.raise_if_capture_blocked, which asks this. Installed BEFORE the
+    # daemon starts and outside the relay block on purpose — a dashboard-driven
+    # upload must block a recording just as a fleet-driven one does, and a device
+    # with the relay disabled still runs those.
+    backend.set_busy_probe(_busy_reason)
     await _daemon.start()
 
     # Start physical button listener on RPi
@@ -695,31 +1036,6 @@ async def lifespan(app: FastAPI):
         from grabette.relay_client import RelayClient
         from grabette.app.routers.system import _pisugar_battery
         from grabette.app.routers.tasks import get_task_manager
-        from grabette.daemon import DaemonState
-        from grabette.jobs import JobStatus, get_job_manager
-
-        def _device_activity() -> str:
-            """Current device activity for the fleet heartbeat:
-            idle | capturing | uploading | processing. Surfaces local, dashboard-
-            initiated work (SLAM push / episode upload) that the fleet can't infer
-            on its own, plus live capture. Best-effort & non-throwing — a bad read
-            just reports 'idle'. All in-memory, so it's cheap on the heartbeat."""
-            try:
-                active = [j for j in get_job_manager().list_jobs()
-                          if j.status in (JobStatus.PENDING, JobStatus.RUNNING)]
-                if any(j.name.startswith("push:") for j in active):
-                    return "processing"  # SLAM convert + push to the dataset
-                if any(j.name.startswith("upload:") for j in active):
-                    return "uploading"
-            except Exception:
-                pass
-            try:
-                d = get_daemon_instance()
-                if d is not None and d.state == DaemonState.RUNNING and d.backend.is_capturing:
-                    return "capturing"
-            except Exception:
-                pass
-            return "idle"
 
         relay = RelayClient(
             base_url=settings.relay_url,

--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -293,31 +293,6 @@ async def _wake_space(session, space_url: str, headers: dict,
             f"Open it once in a browser, then retry.")
 
 
-def _space_quality_summary(quality) -> str:
-    """Why the Space rejected episodes, as one line ("" when it says nothing).
-
-    The Space returns per-episode quality data — the actual reasons, e.g.
-    "missing oakd_calib_offline.json" — and this used to be dropped on the floor
-    here, so a conversion that produced nothing reached the operator as either
-    silence or a bare "processing failed". Reasons are counted rather than
-    listed: twenty episodes failing the same way is one fact, not twenty.
-    """
-    if not isinstance(quality, list):
-        return ""
-    counts: dict[str, int] = {}
-    for ep in quality:
-        if not isinstance(ep, dict):
-            continue
-        for reason in (ep.get("errors") or []):
-            key = str(reason).strip()
-            if key:
-                counts[key] = counts.get(key, 0) + 1
-    if not counts:
-        return ""
-    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:3]
-    return "; ".join(f"{reason} ({n} episode(s))" for reason, n in ranked)
-
-
 def _space_excluded_episodes(quality) -> list[dict]:
     """The episodes the Space left out, one entry each, with its reason.
 
@@ -617,23 +592,16 @@ async def _dispatch_relay_command(cmd: dict) -> dict:
                 continue
             present.append((eid, ep_dir))
 
-        def _incomplete_summary() -> str:
-            """One line naming what is wrong and how often — the operator needs
-            the failing FILE, not a count of failing episodes."""
-            counts: dict[str, int] = {}
-            for item in incomplete:
-                for name in item["missing"]:
-                    counts[name] = counts.get(name, 0) + 1
-            return ", ".join(f"{name} ({n})" for name, n in
-                             sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
-
         # Nothing left to send: fail NOW instead of uploading zero episodes and
         # letting the build discover it has nothing to convert half an hour later,
         # after every other device has finished pushing.
         if not present and incomplete:
+            # The message says WHAT happened; `incomplete` says which episodes and
+            # why, and the fleet renders that per episode. Naming the files here
+            # too just made the operator read the same causes twice.
             return {"status": "error", "role": role,
-                    "message": (f"none of this device's {len(incomplete)} episode(s) can be "
-                                f"converted — {_incomplete_summary()}"),
+                    "message": (f"none of this device's {len(incomplete)} "
+                                f"episode(s) can be converted"),
                     "uploaded": uploaded, "missing": missing, "incomplete": incomplete}
 
         for eid, ep_dir in present:
@@ -672,8 +640,7 @@ async def _dispatch_relay_command(cmd: dict) -> dict:
                "missing": missing, "incomplete": incomplete}
         if incomplete:
             res["message"] = (f"uploaded {len(uploaded)} episode(s); skipped "
-                              f"{len(incomplete)} that cannot be converted — "
-                              f"{_incomplete_summary()}")
+                              f"{len(incomplete)} that cannot be converted")
         return res
 
     if ctype == "process_dataset":
@@ -758,7 +725,7 @@ async def _dispatch_relay_command(cmd: dict) -> dict:
                     sstatus = st.get("status", "running")
                     if sstatus == "done":
                         result_url = st.get("result")
-                        why = _space_quality_summary(st.get("quality"))
+                        excluded = _space_excluded_episodes(st.get("quality"))
                         if not result_url:
                             # "done" with no dataset is NOT a success. The Space
                             # finishes this way when every episode was rejected
@@ -768,19 +735,21 @@ async def _dispatch_relay_command(cmd: dict) -> dict:
                             # that was never created, so the operator got a green
                             # "Open <dataset>" leading to a 404. Fail it here, and
                             # carry the Space's own reasons across.
-                            return {"status": "error", "message": (
+                            # The per-episode reasons ride in `excluded`, which
+                            # the fleet reports on its own. The pointer to the log
+                            # is only for the case where the Space told us nothing
+                            # structured at all — otherwise it would send the
+                            # operator hunting for what is already on their screen.
+                            return {"status": "error", "excluded": excluded, "message": (
                                 "the conversion produced no dataset — no episode "
-                                "made it through" + (f": {why}" if why else
-                                                     " (see the Space log for details)"))}
+                                "made it through"
+                                + ("" if excluded else " (see the Space log for details)"))}
+                        # Succeeded, though episodes may still have been dropped:
+                        # `excluded` names them, and that is the only place they
+                        # need naming.
                         res = {"status": "ok", "result_url": result_url}
-                        # Succeeded, but some episodes may still have been
-                        # dropped. Pass BOTH the summary (why) and the per-episode
-                        # list (which), because the fleet has to answer both.
-                        excluded = _space_excluded_episodes(st.get("quality"))
                         if excluded:
                             res["excluded"] = excluded
-                        if why:
-                            res["message"] = f"some episodes were excluded: {why}"
                         return res
                     if sstatus in ("error", "not_found"):
                         # not_found = the Space forgot the job. Its job list lives in
@@ -788,11 +757,9 @@ async def _dispatch_relay_command(cmd: dict) -> dict:
                         # redeploy) — say so, rather than echoing "not_found".
                         lost = (f"the Space no longer knows job {space_jid} — it restarted "
                                 f"mid-conversion (its job list is kept in memory)")
-                        why = _space_quality_summary(st.get("quality"))
                         detail = st.get("error") or (
                             lost if sstatus == "not_found" else "the Space reported a failure")
-                        return {"status": "error",
-                                "message": f"{detail} — {why}" if why else detail,
+                        return {"status": "error", "message": detail,
                                 "excluded": _space_excluded_episodes(st.get("quality"))}
         except _CommandCancelled:
             return {"status": "cancelled"}

--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -1045,6 +1045,11 @@ async def lifespan(app: FastAPI):
             unassigned_provider=get_task_manager().report_unassigned,
             tasks_rev_provider=get_task_manager().revision,  # re-report when tasks change
             activity_provider=_device_activity,  # device state, reported via heartbeat
+            # Hardware faults (no OAK-D calibration, no angle sensors) — the
+            # device refuses to record in these states, and an operator who can
+            # only find that out by walking up to the grabette and reading its
+            # LED will find it out too late.
+            fault_provider=lambda: getattr(_daemon.backend, "hardware_error", ""),
         )
         relay_task = asyncio.create_task(relay.run(_handle_relay_command))
         logger.info("Relay started → %s (device: %s)", settings.relay_url, settings.device_id)

--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -106,18 +106,30 @@ _SPACE_POLL_TIMEOUT_S = 30.0        # one /api/status poll (retried on failure)
 # --- episode upload (raw dataset) ---------------------------------------------
 # Three layers, because each catches what the one below it cannot:
 #
-# 1. SOCKET timeouts on the Hub client (grabette.hf.install_hub_timeouts). This
-#    is the real cure: huggingface_hub ships its httpx client with timeout=None,
-#    so a link that DEGRADES rather than drops leaves upload_folder waiting on a
-#    socket that never delivers — forever, inside a thread nothing can interrupt.
-#    With per-operation timeouts a stall raises inside the worker, hf_hub retries
-#    it, and the thread DIES. Nothing is left behind.
+# 1. SOCKET timeouts on the Hub client (grabette.hf.install_hub_timeouts).
+#    huggingface_hub ships its httpx client with timeout=None, so a link that
+#    DEGRADES rather than drops leaves a request waiting on a socket that never
+#    delivers — forever, inside a thread nothing can interrupt. With per-operation
+#    timeouts a stall raises inside the worker, hf_hub retries it, and the thread
+#    DIES, leaving nothing behind. Covers everything that goes through httpx: the
+#    JSON API and LFS uploads. It does NOT cover a xet upload, which is the
+#    default path and does its HTTP in Rust — hence layer 3.
 # 2. Retry with backoff here, so one bad minute doesn't sink a build that other
 #    devices already spent twenty minutes uploading for.
-# 3. _UPLOAD_ATTEMPT_TIMEOUT_S as a last-resort bound, for a hang no socket
-#    timeout can see (a wedged filesystem, a future hf_hub that ignores the
-#    client factory). It lets the COMMAND report back — the fleet frees the
-#    device — but the worker thread cannot be killed, so it runs on.
+# 3. A no-PROGRESS watchdog here, for a stall no socket timeout can see: a wedged
+#    filesystem, or — the case that actually matters — a xet upload, whose bytes
+#    move in a Rust HTTP stack that layer 1 does not touch at all. It lets the
+#    COMMAND report back, so the fleet frees the device; the worker thread cannot
+#    be killed, so it runs on.
+#
+# Layer 3 bounds SILENCE, never elapsed time. A total-elapsed cap cannot express
+# the requirement, because any value it takes encodes an assumed throughput, and
+# a healthy upload on a slower link then dies at the deadline — which is the one
+# outcome we must never produce: an episode killed while it was still uploading
+# fine. "No progress for N minutes" is the same guarantee against hangs with no
+# assumption about speed, so a progressing upload runs as long as it needs to.
+# The progress signal comes from grabette.hf's heartbeat (xet's own byte-level
+# callback, plus httpx request/response hooks).
 #
 # Which is why uploads get their OWN executor. asyncio.to_thread uses the DEFAULT
 # one, shared with the daemon's 50 Hz sensor poll, the OAK-D bring-up and
@@ -127,7 +139,20 @@ _SPACE_POLL_TIMEOUT_S = 30.0        # one /api/status poll (retried on failure)
 # and enough of them would starve the capture path itself. Trading frame
 # stability for upload robustness is not a trade worth making, so the two never
 # share a pool: a stalled upload can only ever degrade uploading.
-_UPLOAD_ATTEMPT_TIMEOUT_S = 1800.0  # last-resort bound on ONE episode's attempt
+_UPLOAD_STALL_TIMEOUT_S = 900.0     # no Hub I/O at all for this long = wedged
+_UPLOAD_WATCHDOG_POLL_S = 5.0       # how often staleness is judged. Costs nothing:
+                                    # the wait returns as soon as the upload does,
+                                    # so this only paces the CHECK, not the finish.
+# Used ONLY when grabette.hf reports an INCOMPLETE heartbeat — some upload path
+# is unobservable, so silence there proves nothing and the watchdog above must not
+# rule on it. Partial coverage counts as incomplete on purpose: with only the
+# httpx source wired, a xet transfer emits no marks at all and would read as a
+# stall. Falling back to elapsed time accepts the false positive this whole design
+# exists to avoid, because the alternative — no bound at all — is the original
+# bug: a device pinned as "uploading" until someone restarts the Space.
+# Deliberately far more generous than the 1800s it replaces, being a fallback now
+# rather than the mechanism.
+_UPLOAD_BLIND_ATTEMPT_TIMEOUT_S = 14400.0  # 4 h
 _UPLOAD_MAX_ATTEMPTS = 3
 _UPLOAD_RETRY_BASE_S = 5.0          # backoff: 5s, 10s (doubling per attempt)
 # Deliberately narrow: uploads are sequential within a command, so one worker
@@ -323,6 +348,74 @@ def _space_excluded_episodes(quality) -> list[dict]:
     return out
 
 
+class _UploadStalled(Exception):
+    """An upload stopped making progress and was abandoned."""
+
+
+async def _await_upload(cf, dest: str, attempt: int) -> None:
+    """Wait for one upload, abandoning it only once it goes SILENT.
+
+    Never returns because time passed: the only thing that ends the wait short of
+    completion is the absence of Hub I/O for _UPLOAD_STALL_TIMEOUT_S. An upload
+    that is still moving bytes — however slowly, however large the episode — keeps
+    the heartbeat fresh and is never abandoned. That is the guarantee this
+    function exists to provide.
+
+    Shielded, so a poll that expires does NOT wait for a cancellation the worker
+    thread cannot honour — awaiting that is the very hang being bounded. Nothing
+    here runs off the event loop for longer than a dict lookup: the polling only
+    reads two values from grabette.hf. Raises _UploadStalled, or whatever the
+    upload itself raised.
+    """
+    from grabette import hf as hf_module
+
+    # Mark now, so the clock starts at the submit. Without this, an upload that
+    # never reaches the network at all (a wedged filesystem) would be measured
+    # against whatever unrelated Hub call happened to mark last, or against
+    # nothing at all.
+    hf_module.note_hub_activity()
+    started = time.monotonic()
+    fut = asyncio.wrap_future(cf)
+    try:
+        while True:
+            try:
+                await asyncio.wait_for(asyncio.shield(fut),
+                                       timeout=_UPLOAD_WATCHDOG_POLL_S)
+                return
+            except asyncio.TimeoutError:
+                pass  # just a poll tick, not a verdict
+            # Asked every tick, not once up front. The heartbeat is installed
+            # lazily by HuggingFaceClient._get_api — in the WORKER thread we are
+            # waiting on — so on the process's first upload no source exists yet
+            # when we first get here. Installing it from this coroutine instead
+            # would import the hf_xet extension on the EVENT LOOP (~100ms on x86,
+            # more on a Pi), stalling the daemon's poll for that long. Asking
+            # late costs one poll interval and blocks nothing.
+            if hf_module.heartbeat_is_complete():
+                age = hf_module.hub_activity_age_s()
+                if age is not None and age >= _UPLOAD_STALL_TIMEOUT_S:
+                    raise _UploadStalled(
+                        f"no Hub activity for {age:.0f}s (attempt "
+                        f"{attempt}/{_UPLOAD_MAX_ATTEMPTS}) — the upload is "
+                        f"wedged, not slow; a slow one keeps the heartbeat alive")
+            else:
+                elapsed = time.monotonic() - started
+                if elapsed >= _UPLOAD_BLIND_ATTEMPT_TIMEOUT_S:
+                    logger.error(
+                        "no upload heartbeat source for %s, so the bound fell "
+                        "back to elapsed time — this abandonment MAY be a "
+                        "healthy upload", dest)
+                    raise _UploadStalled(
+                        f"no progress signal available and {elapsed / 3600:.1f}h "
+                        f"elapsed (attempt {attempt}/{_UPLOAD_MAX_ATTEMPTS})")
+    except _UploadStalled:
+        # Nothing will await `fut` again. Consume whatever the abandoned thread
+        # eventually raises, or asyncio logs it as never retrieved — noise that
+        # would land in the operator's journal long after the real error.
+        fut.add_done_callback(lambda f: f.cancelled() or f.exception())
+        raise
+
+
 async def _upload_one_episode(hf, ep_dir, raw_repo: str, dest: str, private: bool,
                               is_cancelled) -> None:
     """Upload one episode dir, bounded and retried. Raises on final failure.
@@ -333,10 +426,12 @@ async def _upload_one_episode(hf, ep_dir, raw_repo: str, dest: str, private: boo
         a doubling backoff, because the alternative is losing every OTHER
         device's completed upload to one bad minute. Re-uploading the same folder
         is safe: an identical commit is a no-op on the Hub.
-      • an attempt that never returns at all — bounded by
-        _UPLOAD_ATTEMPT_TIMEOUT_S so the COMMAND can report back and the fleet
-        can free this device. The worker thread cannot be killed (upload_folder
-        is not interruptible), so it keeps running; it does so on the upload-only
+      • an attempt that STOPS MAKING PROGRESS — abandoned by _await_upload so the
+        COMMAND can report back and the fleet can free this device. Note what is
+        not in that sentence: how long the attempt has taken. A slow attempt is
+        not a failed one, and killing one is the failure mode this whole layer is
+        built to avoid. The worker thread cannot be killed (upload_folder is not
+        interruptible), so it keeps running; it does so on the upload-only
         executor, where it can never delay a recording. See _UPLOAD_WORKERS.
 
     Runs on _get_upload_executor(), never asyncio.to_thread: to_thread means the
@@ -364,13 +459,9 @@ async def _upload_one_episode(hf, ep_dir, raw_repo: str, dest: str, private: boo
         cf = _get_upload_executor().submit(
             hf.upload_episode, ep_dir, raw_repo, None, dest, private)
         try:
-            # Shielded: on timeout we must NOT wait for a cancellation the thread
-            # cannot honour — wait_for would otherwise block until it returned,
-            # which is the very hang we are bounding.
-            await asyncio.wait_for(asyncio.shield(asyncio.wrap_future(cf)),
-                                   timeout=_UPLOAD_ATTEMPT_TIMEOUT_S)
+            await _await_upload(cf, dest, attempt)
             return
-        except asyncio.TimeoutError as e:
+        except _UploadStalled as e:
             last = e
             # Count the stall BEFORE registering the release, never after: a
             # thread that finishes in between would fire the callback first
@@ -379,10 +470,8 @@ async def _upload_one_episode(hf, ep_dir, raw_repo: str, dest: str, private: boo
             # inline, so the window is real, not theoretical.
             stalled = _mark_stalled(1)
             cf.add_done_callback(lambda _f: _mark_stalled(-1))
-            logger.error("upload of %s did not return after %.0fs — abandoning the "
-                         "thread (attempt %d/%d, %d now stalled)", dest,
-                         _UPLOAD_ATTEMPT_TIMEOUT_S, attempt, _UPLOAD_MAX_ATTEMPTS,
-                         stalled)
+            logger.error("abandoning the upload thread for %s: %s (%d now stalled)",
+                         dest, _exc_text(e), stalled)
         except Exception as e:  # noqa: BLE001 — retry whatever the Hub/network raised
             last = e
             logger.warning("upload of %s failed (attempt %d/%d): %s",

--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -588,7 +588,12 @@ async def _dispatch_relay_command(cmd: dict) -> dict:
                 continue
             lacks = missing_files(ep_dir)
             if lacks:
-                incomplete.append({"episode_id": eid, "missing": lacks})
+                # The arm matters as much as the recording: it says which
+                # grabette to go and look at, and it is what lets the fleet
+                # recognise the SAME arm being reported again by the conversion
+                # (which drops the whole recording once an arm is absent) instead
+                # of listing one lost take twice.
+                incomplete.append({"episode_id": eid, "role": role, "missing": lacks})
                 continue
             present.append((eid, ep_dir))
 

--- a/packages/grabette/grabette/app/main.py
+++ b/packages/grabette/grabette/app/main.py
@@ -318,6 +318,36 @@ def _space_quality_summary(quality) -> str:
     return "; ".join(f"{reason} ({n} episode(s))" for reason, n in ranked)
 
 
+def _space_excluded_episodes(quality) -> list[dict]:
+    """The episodes the Space left out, one entry each, with its reason.
+
+    The summary string above answers "why did this fail"; this answers "WHICH of
+    my takes are not in the dataset". They are different questions and the second
+    is the one an operator asks after a build that succeeded — a dataset quietly
+    assembled from 17 of 20 recordings is worse than one that names the 3.
+
+    The Space labels a role-layout episode "20250101_120000/left" (its
+    episode_label), so the recording id and the arm are split back apart here:
+    the fleet keys everything by episode id, and "which arm" is what tells the
+    operator which grabette to go and look at.
+    """
+    if not isinstance(quality, list):
+        return []
+    out = []
+    for ep in quality:
+        if not isinstance(ep, dict) or not ep.get("excluded"):
+            continue
+        name = str(ep.get("name") or "").strip()
+        if not name:
+            continue
+        episode_id, _, role = name.partition("/")
+        reasons = [str(r).strip() for r in (ep.get("errors") or []) if str(r).strip()]
+        out.append({"episode_id": episode_id, "role": role,
+                    "reason": reasons[0] if reasons else
+                              f"excluded by the conversion ({ep.get('verdict') or 'no verdict'})"})
+    return out
+
+
 async def _upload_one_episode(hf, ep_dir, raw_repo: str, dest: str, private: bool,
                               is_cancelled) -> None:
     """Upload one episode dir, bounded and retried. Raises on final failure.
@@ -744,7 +774,11 @@ async def _dispatch_relay_command(cmd: dict) -> dict:
                                                      " (see the Space log for details)"))}
                         res = {"status": "ok", "result_url": result_url}
                         # Succeeded, but some episodes may still have been
-                        # dropped; pass the reasons up so the build can say so.
+                        # dropped. Pass BOTH the summary (why) and the per-episode
+                        # list (which), because the fleet has to answer both.
+                        excluded = _space_excluded_episodes(st.get("quality"))
+                        if excluded:
+                            res["excluded"] = excluded
                         if why:
                             res["message"] = f"some episodes were excluded: {why}"
                         return res
@@ -758,7 +792,8 @@ async def _dispatch_relay_command(cmd: dict) -> dict:
                         detail = st.get("error") or (
                             lost if sstatus == "not_found" else "the Space reported a failure")
                         return {"status": "error",
-                                "message": f"{detail} — {why}" if why else detail}
+                                "message": f"{detail} — {why}" if why else detail,
+                                "excluded": _space_excluded_episodes(st.get("quality"))}
         except _CommandCancelled:
             return {"status": "cancelled"}
         except Exception as e:  # noqa: BLE001

--- a/packages/grabette/grabette/app/routers/oakd.py
+++ b/packages/grabette/grabette/app/routers/oakd.py
@@ -28,6 +28,11 @@ def _status(backend: Backend) -> dict:
         "enabled": bool(enabled),
         "initialized": bool(initialized),
         "initializing": bool(initializing),
+        # Why capture is currently refused ("" = fine). The badge already turned
+        # red for enabled-but-not-initialized; what it could not say is WHICH
+        # failure, and "the OAK-D is red" sends an operator hunting for a cable
+        # when the fault is a calibration the device can't read.
+        "hardware_error": getattr(backend, "hardware_error", ""),
     }
 
 

--- a/packages/grabette/grabette/app/routers/tasks.py
+++ b/packages/grabette/grabette/app/routers/tasks.py
@@ -155,6 +155,12 @@ async def start_capture(
     scheduler = get_capture_scheduler()
     if scheduler.is_scheduled():
         raise HTTPException(status_code=409, detail="A start is already scheduled")
+    # Hardware fault or dataset work in progress. Checked BEFORE the episode is
+    # created so a refusal leaves no half-made episode to discard, and reported
+    # as a conflict with the device's state rather than a server error.
+    blocked = backend.hardware_error or backend.busy_reason
+    if blocked:
+        raise HTTPException(status_code=409, detail=blocked)
 
     # If this device is grouped, a start here behaves like the fleet "start
     # group recording" button: the GROUP's task wins and the start is
@@ -189,17 +195,24 @@ async def start_capture(
     )
     episode_dir = tm.episode_dir(episode_id)
 
-    if target is not None:
-        await scheduler.schedule(backend, tm, episode_dir, target)
-        return {
-            "episode_id": episode_id,
-            "status": "scheduled",
-            "start_at_utc": sync["scheduled_start_utc"],
-            "peers": sync.get("peers", []),
-        }
-
+    # Both start paths can still be refused here — the up-front check above can
+    # race work that begins right after it. RuntimeError is the gate's (and
+    # "Already capturing"'s) language, and it is a conflict with the device's
+    # state: without this it reaches the dashboard as the global handler's
+    # "Internal server error", which tells the operator nothing to act on.
     try:
+        if target is not None:
+            await scheduler.schedule(backend, tm, episode_dir, target)
+            return {
+                "episode_id": episode_id,
+                "status": "scheduled",
+                "start_at_utc": sync["scheduled_start_utc"],
+                "peers": sync.get("peers", []),
+            }
         await backend.start_capture(episode_dir)
+    except RuntimeError as e:
+        tm.discard_pending_episode()
+        raise HTTPException(status_code=409, detail=str(e)) from e
     except Exception:
         tm.discard_pending_episode()
         raise

--- a/packages/grabette/grabette/auth.py
+++ b/packages/grabette/grabette/auth.py
@@ -59,7 +59,7 @@ def _write_secret(path: Path, text: str) -> None:
 
 _HOSTNAME = socket.gethostname()
 
-_DEFAULT_RELAY_URL = "https://glannuzel-fleet-test.hf.space"
+_DEFAULT_RELAY_URL = "https://pollen-robotics-grabette-fleet.hf.space"
 _RELAY_URL = os.environ.get("GRABETTE_RELAY_URL", _DEFAULT_RELAY_URL).rstrip("/")
 OAUTH_CALLBACK_PATH = "/api/hf-auth/oauth/callback"
 

--- a/packages/grabette/grabette/backend/base.py
+++ b/packages/grabette/grabette/backend/base.py
@@ -54,6 +54,70 @@ class Backend(ABC):
         Default: no-op (backends with no slow init)."""
         return None
 
+    @property
+    def hardware_error(self) -> str:
+        """Why this device must not record right now ("" = fine).
+
+        A backend sets this when it detects a fault that would make every
+        recorded episode unusable downstream (see RpiBackend: no OAK-D offline
+        calibration). Capture is refused while it is set, and the button
+        listener blinks the error pattern so the fault is visible on the device
+        itself. Default: no backend-detectable fault."""
+        return ""
+
+    # --- busy gate -----------------------------------------------------------
+    # A recording must not start on top of dataset work. On a Pi the upload is
+    # not a sleeping socket: hf_xet chunks and hashes in native threads, so it
+    # competes for CPU with the H.264 encoders and the OAK-D drainers and the
+    # episode comes out with dropped frames and jittered timestamps — an episode
+    # that looks recorded and is quietly worse than nothing.
+    #
+    # The fleet already refuses to start a recording on a device it knows is
+    # uploading, but that gate is fleet-side only: the PHYSICAL BUTTON and the
+    # local dashboard walk straight past it. So the device enforces it too, for
+    # itself, whoever asks.
+    #
+    # Injected as a probe rather than read directly: knowing about HF uploads is
+    # not a backend's business. app/main.py owns that knowledge (it is the same
+    # source the fleet heartbeat reports from) and installs it at startup, so
+    # there is exactly one answer to "what is this device doing".
+
+    def set_busy_probe(self, probe) -> None:
+        """Install the callable answering "why is this device too busy to
+        record?" — a reason string, or "" when free."""
+        self._busy_probe = probe
+
+    @property
+    def busy_reason(self) -> str:
+        """Why capture is refused for BUSY reasons ("" = free).
+
+        Never raises: a probe that fails must not take recording down with it,
+        so a broken probe reads as free. Distinct from hardware_error — that one
+        is a fault needing intervention, this one clears on its own."""
+        probe = getattr(self, "_busy_probe", None)
+        if probe is None:
+            return ""
+        try:
+            return probe() or ""
+        except Exception:  # noqa: BLE001 — a probe must never block recording
+            return ""
+
+    def raise_if_capture_blocked(self) -> None:
+        """Refuse to start a capture that would produce unusable data.
+
+        Public and called from EVERY start path — the backends' start_capture
+        and CaptureScheduler.schedule — because gating the callers one by one is
+        how the next start path silently bypasses it.
+
+        RuntimeError so it travels like any other start failure: the REST routes
+        turn it into an error response, the relay reports it to the fleet, and
+        the button listener logs it (the LED is already showing the state)."""
+        if self.hardware_error:
+            raise RuntimeError(self.hardware_error)
+        busy = self.busy_reason
+        if busy:
+            raise RuntimeError(busy)
+
     @abstractmethod
     async def stop_capture(self) -> CaptureStatus: ...
 

--- a/packages/grabette/grabette/backend/mock.py
+++ b/packages/grabette/grabette/backend/mock.py
@@ -72,6 +72,7 @@ class MockBackend(Backend):
     async def start_capture(self, episode_dir: Path) -> None:
         if self._capturing:
             raise RuntimeError("Already capturing")
+        self.raise_if_capture_blocked()
         self._capturing = True
         self._capture_start = time.time()
         self._episode_dir = episode_dir

--- a/packages/grabette/grabette/backend/mock.py
+++ b/packages/grabette/grabette/backend/mock.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import math
 import random
@@ -11,7 +10,7 @@ from pathlib import Path
 from grabette.backend.base import Backend
 from grabette.config import settings
 from grabette.models import AngleSample, CaptureStatus, IMUSample, SensorState
-from grabette.output import write_imu_json
+from grabette.output import write_imu_json, write_json_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -254,4 +253,4 @@ class MockBackend(Backend):
         sync_meta = self._take_sync_metadata()
         if sync_meta:
             meta["sync"] = sync_meta
-        (episode_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
+        write_json_atomic(episode_dir / "metadata.json", meta)

--- a/packages/grabette/grabette/backend/rpi.py
+++ b/packages/grabette/grabette/backend/rpi.py
@@ -17,6 +17,7 @@ from grabette.config import settings
 from grabette.errors import exc_text as _exc_text
 from grabette.hardware.frames import build_frames_payload
 from grabette.models import AngleSample, CaptureStatus, IMUSample, SensorState
+from grabette.output import write_json_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -729,7 +730,7 @@ class RpiBackend(Backend):
                     )
                 # metadata.json goes last so its presence signals the episode
                 # is fully saved to any watcher.
-                (episode_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
+                write_json_atomic(episode_dir / "metadata.json", meta)
         except Exception:
             logger.exception("Deferred file writes failed")
         writes_ms = (time.monotonic() - _t) * 1000

--- a/packages/grabette/grabette/backend/rpi.py
+++ b/packages/grabette/grabette/backend/rpi.py
@@ -54,6 +54,10 @@ class RpiBackend(Backend):
         # Distinguishes the normal warm-up window from a genuine init failure
         # so the UI can show "Starting…" instead of "Error".
         self._oakd_initializing = False
+        # Non-empty when this grabette is in a state where recording would
+        # produce unusable data (currently: no OAK-D offline calibration). It
+        # BLOCKS capture and drives the error LED — see hardware_error.
+        self._hw_error = ""
         self._episode_dir: Path | None = None
         self._enable_angle = enable_angle
         self._enable_oakd = enable_oakd
@@ -103,12 +107,29 @@ class RpiBackend(Backend):
         logger.info("RpiBackend started")
 
     def _init_oakd(self) -> None:
-        """Initialize OAK-D SR (always-on pipeline, used for live view + recording)."""
+        """Initialize OAK-D SR (always-on pipeline, used for live view + recording).
+
+        A missing/unusable offline calibration is singled out from every other
+        init failure: the OAK-D is reachable, so the device looks healthy, yet
+        every episode it records is unconvertible (the SLAM Space rejects them
+        with "missing oakd_calib_offline.json"). That one is latched as a
+        hardware error, which refuses capture and blinks the error pattern.
+        Other failures keep the historical behaviour (log + carry on without the
+        OAK-D) so a deliberately OAK-less bench setup still works.
+        """
+        from grabette.hardware.oakd import OakdCalibrationError, OakdCapture
         try:
-            from grabette.hardware.oakd import OakdCapture
             self._oakd = OakdCapture(self._sync)
             self._oakd.init_device()
+            self._hw_error = ""
             logger.info("OAK-D SR initialized")
+        except OakdCalibrationError as e:
+            self._oakd = None
+            self._hw_error = (
+                f"{e} — this grabette cannot record convertible episodes. "
+                "Power-cycle it; if it persists the OAK-D needs re-flashing."
+            )
+            logger.error("OAK-D calibration unusable — recording disabled: %s", e)
         except Exception as e:
             logger.warning("OAK-D not available, continuing without it: %s", e)
             self._oakd = None
@@ -385,6 +406,10 @@ class RpiBackend(Backend):
         if not self.is_oakd_initialized:
             await self.set_oakd_enabled(True)
             self._oakd_auto_enabled = True
+        # Refuse the warm-up too, not just start_capture: this runs BEFORE a
+        # group's shared T0, so failing here lets the peer/fleet learn this
+        # device is out before the synchronized start rather than at T0.
+        self.raise_if_capture_blocked()
         if self._needs_reinit:
             self._reinit_hardware()
         if self._oakd and self._oakd.is_initialized:
@@ -416,6 +441,16 @@ class RpiBackend(Backend):
             if not self.is_oakd_initialized:
                 await self.set_oakd_enabled(True)
                 self._oakd_auto_enabled = True
+            # Hard gate: a grabette that cannot produce oakd_calib_offline.json
+            # records episodes no one can convert. Refusing here — rather than
+            # discovering it on the SLAM Space, after the upload — is the whole
+            # point: the operator finds out while the take can still be redone.
+            #
+            # Checked AFTER the bring-up above, never before: the bring-up IS the
+            # retry, and a fault latched at boot would otherwise refuse every
+            # start without ever re-reading the calibration, leaving a reboot as
+            # the only way out. Reseat the cable, press again, and it clears.
+            self.raise_if_capture_blocked()
 
             # Safety net: the previous stop_capture schedules the camera re-init
             # to run during idle (see stop_capture). If a restart beats it, do
@@ -681,9 +716,14 @@ class RpiBackend(Backend):
         angle_count = self._angle.sample_count if self._angle else 0
         imu_count = self._oakd.imu_sample_count if (self._oakd and self._oakd.is_recording) else 0
 
+        # NB: this runs on the daemon's 50 Hz poll loop (get_state builds it), so
+        # everything here must stay in-memory and cheap. busy_reason measures
+        # ~1 us — keep it that way rather than caching it, since the gate reads
+        # the same value and must not answer from a stale one.
         return CaptureStatus(
             is_capturing=self._capturing,
             is_starting=self._starting,
+            blocked_reason=self._hw_error or self.busy_reason,
             episode_id=self._episode_dir.name if self._episode_dir else None,
             duration_seconds=round(duration, 2),
             frame_count=frame_count,
@@ -702,6 +742,16 @@ class RpiBackend(Backend):
     @property
     def is_stopping(self) -> bool:
         return self._stopping
+
+    @property
+    def hardware_error(self) -> str:
+        """Why this grabette must not record right now ("" = fine).
+
+        Set by _init_oakd when the OAK-D can't produce an offline calibration.
+        Read by start_capture/prepare_capture (which refuse) and by the button
+        listener's LED monitor (which blinks the error pattern), so the fault is
+        visible on the device itself and not only in the logs."""
+        return self._hw_error
 
     def get_frame_jpeg(self) -> bytes | None:
         """Capture a JPEG frame from picamera2.

--- a/packages/grabette/grabette/backend/rpi.py
+++ b/packages/grabette/grabette/backend/rpi.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from grabette.backend.base import Backend
 from grabette.config import settings
+from grabette.errors import exc_text as _exc_text
 from grabette.hardware.frames import build_frames_payload
 from grabette.models import AngleSample, CaptureStatus, IMUSample, SensorState
 
@@ -37,6 +38,20 @@ FPS = 46
 OAKD_READY_TIMEOUT_S = 5.0
 
 
+# Hardware faults that make this grabette unable to record CONVERTIBLE episodes.
+# Keyed, not one string: the two are independent, and a single field would let
+# a successful OAK-D bring-up quietly clear a live angle-sensor fault. Listed in
+# report order so a device with both always words it the same way.
+_HW_OAKD = "oakd_calibration"
+_HW_ANGLE = "angle_sensors"
+_HW_ORDER = (_HW_OAKD, _HW_ANGLE)
+
+_ANGLE_FAULT_MSG = (
+    "the gripper angle sensors {what} — episodes would carry no angle_data.json "
+    "and could never be converted. Check the AS5600 wiring / I2C bus."
+)
+
+
 class RpiBackend(Backend):
     """Backend using real RPi camera + AS5600 angle sensors + OAK-D SR."""
 
@@ -54,10 +69,11 @@ class RpiBackend(Backend):
         # Distinguishes the normal warm-up window from a genuine init failure
         # so the UI can show "Starting…" instead of "Error".
         self._oakd_initializing = False
-        # Non-empty when this grabette is in a state where recording would
-        # produce unusable data (currently: no OAK-D offline calibration). It
-        # BLOCKS capture and drives the error LED — see hardware_error.
-        self._hw_error = ""
+        # Live hardware faults, keyed by _HW_* — each one a state in which
+        # recording would produce unusable data (no OAK-D offline calibration, no
+        # angle sensors). Any of them BLOCKS capture and drives the error LED —
+        # see hardware_error.
+        self._hw_faults: dict[str, str] = {}
         self._episode_dir: Path | None = None
         self._enable_angle = enable_angle
         self._enable_oakd = enable_oakd
@@ -121,28 +137,44 @@ class RpiBackend(Backend):
         try:
             self._oakd = OakdCapture(self._sync)
             self._oakd.init_device()
-            self._hw_error = ""
+            self._clear_hw_error(_HW_OAKD)
             logger.info("OAK-D SR initialized")
         except OakdCalibrationError as e:
             self._oakd = None
-            self._hw_error = (
+            self._set_hw_error(_HW_OAKD, (
                 f"{e} — this grabette cannot record convertible episodes. "
                 "Power-cycle it; if it persists the OAK-D needs re-flashing."
-            )
+            ))
             logger.error("OAK-D calibration unusable — recording disabled: %s", e)
         except Exception as e:
             logger.warning("OAK-D not available, continuing without it: %s", e)
             self._oakd = None
 
     def _init_angle_sensors(self) -> None:
+        """Bring up the AS5600 gripper encoders.
+
+        Failing here is a hardware fault, not a degraded mode: stop_capture only
+        writes angle_data.json when there are samples, so a device without angle
+        sensors records episodes that carry no gripper channel at all — and
+        angle_data.json is a REQUIRED conversion input. The old "continuing
+        without them" left a grabette filling its card with episodes the SLAM
+        Space would reject one by one, which is exactly the OAK-D calibration
+        incident with a different sensor.
+
+        Only when the sensors are meant to be there (self._enable_angle): a
+        deliberately angle-less bench setup is a choice, not a fault.
+        """
         try:
             from grabette.hardware.angle import AngleCapture
             self._angle = AngleCapture(self._sync)
             self._angle.init_sensors()
+            self._clear_hw_error(_HW_ANGLE)
             logger.info("Angle sensors initialized")
-        except Exception:
-            logger.warning("Angle sensors not available, continuing without them")
+        except Exception as e:  # noqa: BLE001
             self._angle = None
+            self._set_hw_error(_HW_ANGLE, _ANGLE_FAULT_MSG.format(
+                what=f"could not be initialised ({_exc_text(e)})"))
+            logger.error("Angle sensors unusable — recording disabled: %s", e)
 
     async def stop(self) -> None:
         if self._capturing:
@@ -403,15 +435,20 @@ class RpiBackend(Backend):
         # Keep it warm for the imminent capture (don't let a keep-alive power
         # it down between now and T0).
         self._cancel_oakd_keepalive()
+        busy = self.busy_reason
+        if busy:
+            raise RuntimeError(busy)
         if not self.is_oakd_initialized:
             await self.set_oakd_enabled(True)
             self._oakd_auto_enabled = True
+        if self._needs_reinit:
+            self._reinit_hardware()
+        elif self._enable_angle and self._angle is None:
+            self._init_angle_sensors()  # the retry that can clear the fault below
         # Refuse the warm-up too, not just start_capture: this runs BEFORE a
         # group's shared T0, so failing here lets the peer/fleet learn this
         # device is out before the synchronized start rather than at T0.
         self.raise_if_capture_blocked()
-        if self._needs_reinit:
-            self._reinit_hardware()
         if self._oakd and self._oakd.is_initialized:
             await loop.run_in_executor(
                 None, self._oakd.wait_until_ready, OAKD_READY_TIMEOUT_S,
@@ -438,25 +475,41 @@ class RpiBackend(Backend):
             # init are logged inside _init_oakd and leave _oakd=None; the rest
             # of start_capture handles that gracefully. We then own its power and
             # will auto-power-down after the keep-alive window once capture stops.
+            # BUSY is refused first, before any hardware work: an OAK-D cold
+            # boot is ~10s of CPU, and doing it for a recording we are about to
+            # refuse would spend exactly the cycles the busy gate exists to
+            # protect (the upload it is competing with).
+            busy = self.busy_reason
+            if busy:
+                raise RuntimeError(busy)
+
             if not self.is_oakd_initialized:
                 await self.set_oakd_enabled(True)
                 self._oakd_auto_enabled = True
-            # Hard gate: a grabette that cannot produce oakd_calib_offline.json
-            # records episodes no one can convert. Refusing here — rather than
-            # discovering it on the SLAM Space, after the upload — is the whole
-            # point: the operator finds out while the take can still be redone.
-            #
-            # Checked AFTER the bring-up above, never before: the bring-up IS the
-            # retry, and a fault latched at boot would otherwise refuse every
-            # start without ever re-reading the calibration, leaving a reboot as
-            # the only way out. Reseat the cable, press again, and it clears.
-            self.raise_if_capture_blocked()
 
             # Safety net: the previous stop_capture schedules the camera re-init
             # to run during idle (see stop_capture). If a restart beats it, do
             # it now.
             if self._needs_reinit:
                 self._reinit_hardware()
+            elif self._enable_angle and self._angle is None:
+                # Nothing scheduled a re-init (first start after boot, or an
+                # earlier attempt that failed) yet the sensors are missing. Retry
+                # here: this bring-up is what clears the fault checked below, and
+                # without it a fault latched at boot would refuse every start
+                # forever with a reboot as the only way out.
+                self._init_angle_sensors()
+
+            # Hard gate: a grabette that cannot produce oakd_calib_offline.json —
+            # or no angle data at all — records episodes no one can convert.
+            # Refusing here, rather than discovering it on the SLAM Space after
+            # the upload, is the whole point: the operator finds out while the
+            # take can still be redone.
+            #
+            # Checked AFTER every bring-up above, never before, for the same
+            # reason: the bring-up IS the retry. Reseat the cable, press again,
+            # and it clears.
+            self.raise_if_capture_blocked()
 
             # Defer the recording clock until the OAK-D is producing valid frames
             # (autoexposure + depth converged), so t=0 lands on good data instead
@@ -516,6 +569,7 @@ class RpiBackend(Backend):
             angle_data = self._angle.stop()
             angle_count = len(angle_data.samples)
             angle_samples = angle_data.samples if angle_data.samples else None
+        self._note_angle_output(angle_samples)
         t_phases["angle_stop"] = (time.monotonic() - _t) * 1000
 
         # Finalize OAK and RPi camera concurrently. Both flip their "recording"
@@ -723,7 +777,7 @@ class RpiBackend(Backend):
         return CaptureStatus(
             is_capturing=self._capturing,
             is_starting=self._starting,
-            blocked_reason=self._hw_error or self.busy_reason,
+            blocked_reason=self.hardware_error or self.busy_reason,
             episode_id=self._episode_dir.name if self._episode_dir else None,
             duration_seconds=round(duration, 2),
             frame_count=frame_count,
@@ -743,15 +797,53 @@ class RpiBackend(Backend):
     def is_stopping(self) -> bool:
         return self._stopping
 
+    def _note_angle_output(self, angle_samples) -> None:
+        """Record whether the finished recording actually produced angle data.
+
+        The OTHER way a device silently fills its card with unconvertible
+        episodes: the sensors came up fine, then produced nothing for the whole
+        take — so stop_capture writes no angle_data.json and the episode is
+        rejected upstream, exactly as if they had never initialised. This episode
+        is already lost, but the SESSION doesn't have to be: latch the fault so
+        the next start is refused and the LED says why. Zero samples across an
+        entire recording is a dead sensor, not a hiccup.
+
+        Samples present clears the fault: they are proof the sensors work, which
+        is the only proof an init alone cannot give."""
+        if not self._enable_angle:
+            return  # deliberately angle-less setup — nothing to judge
+        if angle_samples is None:
+            self._set_hw_error(_HW_ANGLE, _ANGLE_FAULT_MSG.format(
+                what="produced no samples during the last recording"))
+            logger.error("Angle sensors produced no samples for %s — recording "
+                         "disabled until they come back",
+                         self._episode_dir.name if self._episode_dir else "?")
+        else:
+            self._clear_hw_error(_HW_ANGLE)
+
+    def _set_hw_error(self, key: str, message: str) -> None:
+        self._hw_faults[key] = message
+
+    def _clear_hw_error(self, key: str) -> None:
+        """Drop one fault — only ever called by the bring-up that proves it gone.
+
+        Per key, never wholesale: clearing everything on one sensor's success is
+        how a live fault on the other silently disappears."""
+        self._hw_faults.pop(key, None)
+
     @property
     def hardware_error(self) -> str:
         """Why this grabette must not record right now ("" = fine).
 
-        Set by _init_oakd when the OAK-D can't produce an offline calibration.
-        Read by start_capture/prepare_capture (which refuse) and by the button
-        listener's LED monitor (which blinks the error pattern), so the fault is
-        visible on the device itself and not only in the logs."""
-        return self._hw_error
+        Set by _init_oakd (no OAK-D offline calibration) and _init_angle_sensors
+        / stop_capture (no gripper angle data). Read by start_capture and
+        prepare_capture (which refuse) and by the button listener's LED monitor
+        (which blinks the error pattern), so a fault is visible on the device
+        itself and not only in the logs. Every live fault is reported, in a fixed
+        order: fixing one and still being refused, with no clue about the other,
+        is a maddening way to spend an afternoon."""
+        return " / ".join(self._hw_faults[k] for k in _HW_ORDER
+                          if k in self._hw_faults)
 
     def get_frame_jpeg(self) -> bytes | None:
         """Capture a JPEG frame from picamera2.

--- a/packages/grabette/grabette/button_listener.py
+++ b/packages/grabette/grabette/button_listener.py
@@ -10,6 +10,10 @@ BOTH grabettes reflect their own status, even the peer started via the fleet:
   - Blink:      initializing (warming up / waiting for the shared T0)
   - Solid:      recording in progress
   - Fast blink: stopping (from the stop until the capture is fully torn down)
+  - 1 pulse, pause, repeat:  busy with dataset work (upload / conversion) —
+    recording is refused until it finishes (see Backend.busy_reason)
+  - 3 pulses, pause, repeat: hardware fault — this device REFUSES to record
+    (see Backend.hardware_error; today: no usable OAK-D offline calibration)
 (Teleop mode reuses the LED: solid = sending, off = repositioning.)
 """
 
@@ -38,6 +42,20 @@ STOP_ACK_S = 1.2
 # internal states, which must NOT flash the LED off mid-initialization. An 'off'
 # has to persist this long (while blinking/solid) before it's applied.
 _OFF_DEBOUNCE_S = 1.0
+
+# Hardware-fault pattern: N short pulses, then a dark gap, repeating. Read off
+# the LED alone, it must not be confusable with the busy patterns — hence a burst
+# rather than yet another duty cycle.
+_ERROR_PULSES = 3
+_ERROR_PULSE_ON_S = 0.1
+_ERROR_PULSE_OFF_S = 0.1
+_ERROR_GAP_S = 1.0
+
+# Busy pattern: the SAME burst shape with a single pulse and a longer pause, so
+# the two read as one family — count the blips: one = busy, three = broken. A
+# busy device must not look idle (dark), or an operator picks it up and presses.
+_BUSY_PULSES = 1
+_BUSY_GAP_S = 1.5
 
 
 class ButtonListener:
@@ -105,9 +123,14 @@ class ButtonListener:
         - Capturing     : press stops the capture
         - Idle          : press starts a capture
         """
-        btn = self._button
+        # This thread does NOT touch the LED: _led_monitor is the single writer
+        # (see start()). It used to switch the LED off on entry and on exit, which
+        # was harmless while every run began and ended idle — but a device that
+        # comes up in a hardware fault starts on the error pattern, and a stray
+        # led_off() here would race the monitor, win, and leave the LED dark with
+        # the monitor believing it had already applied the pattern. Teardown is
+        # covered by stop(), which switches the LED off after joining both threads.
         try:
-            btn.led_off()
             while not self._stop_event.is_set():
                 self._wait_for_press()
                 if self._stop_event.is_set():
@@ -115,22 +138,27 @@ class ButtonListener:
                 self._on_press()
         except Exception:
             logger.exception("Button listener error")
-        finally:
-            if btn is not None:
-                btn.led_off()
 
     # -- LED state monitor (runs in its own thread) --
 
     def _desired_led(self) -> str:
         """The LED state that reflects what this device is doing right now:
-        'on' | 'blink' | 'blink_fast' | 'off'. State-driven (not press-driven) so
-        every group member shows its own status:
+        'error' | 'on' | 'blink' | 'blink_fast' | 'off'. State-driven (not
+        press-driven) so every group member shows its own status:
           off        → idle
           blink      → initializing (warming up / waiting for the shared T0)
           on         → recording (solid)
-          blink_fast → stopping (from stop until the capture is fully torn down)."""
+          blink_fast → stopping (from stop until the capture is fully torn down)
+          busy       → dataset work in progress, capture refused (1 pulse / pause)
+          error      → hardware fault, capture refused (3 pulses / pause)."""
         from grabette.capture_scheduler import get_capture_scheduler
         b = self._backend
+        # Highest priority, above teleop and above any capture state: the device
+        # is refusing to record, and the LED is the only place an operator holding
+        # a screenless grabette can find that out. A fault that is outranked by a
+        # busy pattern is a fault nobody sees.
+        if getattr(b, "hardware_error", ""):
+            return "error"
         if b.is_teleop_active:
             return "on" if b.is_teleop_sending else "off"
         # Stopping wins over is_capturing: the backend keeps is_capturing True
@@ -149,6 +177,11 @@ class ButtonListener:
             return "blink"       # initializing: warming up / waiting for T0
         if b.is_capturing:
             return "on"          # recording (solid)
+        # Below the capture states on purpose: if a recording IS somehow running,
+        # showing it wins. Above idle, because a device busy uploading is not
+        # available, and dark is the signal for available.
+        if getattr(b, "busy_reason", ""):
+            return "busy"
         return "off"             # idle
 
     def _led_monitor(self) -> None:
@@ -168,7 +201,12 @@ class ButtonListener:
         while not self._stop_event.is_set():
             try:
                 raw = self._desired_led()
-                if self._backend.is_teleop_active:
+                if raw == "error":
+                    # Never debounced and never latched away: while the fault
+                    # stands the LED shows nothing else.
+                    want = raw
+                    off_since = None
+                elif self._backend.is_teleop_active:
                     want = raw  # teleop: snappy, no latching
                     off_since = None
                 elif raw == "off":
@@ -185,7 +223,13 @@ class ButtonListener:
                     # scheduled/starting reading — hold solid until stop/idle.
                     want = "on" if (raw == "blink" and applied == "on") else raw
                 if want != applied:
-                    if want == "on":
+                    if want == "error":
+                        btn.led_pulses(_ERROR_PULSES, _ERROR_PULSE_ON_S,
+                                       _ERROR_PULSE_OFF_S, _ERROR_GAP_S)
+                    elif want == "busy":
+                        btn.led_pulses(_BUSY_PULSES, _ERROR_PULSE_ON_S,
+                                       _ERROR_PULSE_OFF_S, _BUSY_GAP_S)
+                    elif want == "on":
                         btn.led_on()
                     elif want == "blink":
                         btn.led_blink(0.3)        # initializing: steady blink

--- a/packages/grabette/grabette/capture_scheduler.py
+++ b/packages/grabette/grabette/capture_scheduler.py
@@ -49,7 +49,15 @@ class CaptureScheduler:
         return self._start_at_utc if self.is_scheduled() else None
 
     async def schedule(self, backend, sm, episode_dir: Path, start_at_utc: datetime) -> None:
-        """Start a background wait-then-start task for a synchronized start."""
+        """Start a background wait-then-start task for a synchronized start.
+
+        Refuses up front if the device can't record (hardware fault, or busy
+        with dataset work). start_capture checks again at T0 — that is the
+        authoritative gate — but a refusal only surfacing then would reach the
+        operator as a group start that was accepted and then quietly didn't
+        happen, seconds later, in a background task. Checking here turns it into
+        an immediate, attributable error at the press."""
+        backend.raise_if_capture_blocked()
         self._start_at_utc = start_at_utc
         self._task = asyncio.create_task(
             self._wait_and_start(backend, sm, episode_dir, start_at_utc),

--- a/packages/grabette/grabette/config.py
+++ b/packages/grabette/grabette/config.py
@@ -84,7 +84,7 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
 
     # Fleet relay
-    relay_url: str = "https://glannuzel-fleet-test.hf.space"
+    relay_url: str = "https://pollen-robotics-grabette-fleet.hf.space"
     relay_enabled: bool = True
     device_id: str = ""
     device_name: str = ""

--- a/packages/grabette/grabette/daemon.py
+++ b/packages/grabette/grabette/daemon.py
@@ -147,6 +147,12 @@ class Daemon:
             "state": self.state.value,
             "backend": type(self.backend).__name__,
             "error": self._error,
+            # A backend-detected fault that makes capture refuse ("" = none).
+            # Distinct from "error" above, which is the daemon's own start-up
+            # failure: here the daemon runs fine, the HARDWARE can't produce
+            # usable episodes. Rides on the status dict so it reaches the local
+            # dashboard and the fleet's get_state without a second endpoint.
+            "hardware_error": getattr(self.backend, "hardware_error", ""),
         }
         if self.state == DaemonState.RUNNING:
             result["sensor"] = self.latest_state().model_dump()

--- a/packages/grabette/grabette/episode_check.py
+++ b/packages/grabette/grabette/episode_check.py
@@ -1,0 +1,67 @@
+"""Is a recorded episode complete enough to be convertible?
+
+The SLAM Space runs the authoritative check (grabette_postprocess
+checks.recording): it decodes videos, counts samples and looks for stuck joints.
+This is the cheap local mirror of the same contract — presence and non-emptiness
+only, no decoding — so the device can answer the one question that matters
+BEFORE it spends minutes pushing gigabytes to the Hub:
+
+    will this episode be thrown out on the other side?
+
+That question used to be answered far too late. A grabette whose OAK-D never
+produced oakd_calib_offline.json uploaded a whole session normally; the Space
+then rejected every episode ("missing oakd_calib_offline.json"), reported no
+usable recording, and the operator learned about it after the upload, from a
+dataset link that 404'd. Checking here turns that into a named, per-episode
+reason attached to the upload result, while the take could still be redone.
+
+Deliberately NOT a re-implementation of the full check: anything this passes may
+still be rejected upstream (a truncated video, an angle channel that never
+moved). It is a fast pre-filter for the failures that are both common and
+locally visible, not a second source of truth.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Files every episode must carry for the raw → LeRobot conversion to be possible.
+# Mirrors the required inputs of grabette_postprocess.checks.recording:
+#   SLAM     — oakd_left.mp4 + timestamps, depth + timestamps, imu, offline calib
+#   Dataset  — angle_data.json (gripper), raw_video.mp4 (Arducam)
+REQUIRED_FILES = (
+    "oakd_left.mp4",
+    "oakd_left_timestamps.json",
+    "oakd_depth_timestamps.json",
+    "oakd_imu.json",
+    "oakd_calib_offline.json",
+    "angle_data.json",
+    "raw_video.mp4",
+)
+
+# Depth ships either as a muxed file or as the PNG sequence it is built from
+# (stop_recording muxes the directory into the .mkv, so which one is present
+# depends on when the episode was recorded). Either satisfies the requirement.
+_DEPTH_ALTERNATIVES = ("oakd_depth.mkv", "oakd_depth")
+
+
+def _present(path: Path) -> bool:
+    """A file that exists but is empty is missing for our purposes — a zero-byte
+    video or JSON fails upstream exactly like an absent one, and an interrupted
+    recording is the usual way to produce it."""
+    if path.is_dir():
+        return any(path.iterdir())
+    return path.is_file() and path.stat().st_size > 0
+
+
+def missing_files(episode_dir: Path) -> list[str]:
+    """The required artifacts this episode lacks, in a stable order ([] = fine).
+
+    Names are returned as-is so they can be shown to an operator verbatim: the
+    string the Space reports is the string the device reports."""
+    episode_dir = Path(episode_dir)
+    missing = [name for name in REQUIRED_FILES
+               if not _present(episode_dir / name)]
+    if not any(_present(episode_dir / alt) for alt in _DEPTH_ALTERNATIVES):
+        missing.append(_DEPTH_ALTERNATIVES[0])
+    return sorted(missing)

--- a/packages/grabette/grabette/errors.py
+++ b/packages/grabette/grabette/errors.py
@@ -1,0 +1,15 @@
+"""Small shared error helpers."""
+
+from __future__ import annotations
+
+
+def exc_text(e: BaseException) -> str:
+    """Never-empty description of an exception.
+
+    `str(asyncio.TimeoutError())` is the EMPTY STRING, so interpolating an
+    exception straight into a message can report only "processing failed:" —
+    leaving the operator nothing to act on, and the failure that says the least
+    is the most common one. Fall back to the class name, which at least names
+    the failure mode.
+    """
+    return str(e).strip() or type(e).__name__

--- a/packages/grabette/grabette/hardware/button.py
+++ b/packages/grabette/grabette/hardware/button.py
@@ -82,16 +82,61 @@ class LedButton:
         self._led_request.set_value(self._led_pin, Value.INACTIVE)
 
     def led_blink(self, interval: float = 0.3) -> None:
-        self._blink_stop.clear()
-
-        def _blink() -> None:
+        def _blink(stop: threading.Event) -> None:
             state = Value.INACTIVE
-            while not self._blink_stop.is_set():
+            while not stop.is_set():
                 self._led_request.set_value(self._led_pin, state)
                 state = Value.ACTIVE if state == Value.INACTIVE else Value.INACTIVE
                 time.sleep(interval)
 
-        self._blink_thread = threading.Thread(target=_blink, daemon=True)
+        self._start_pattern(_blink)
+
+    def led_pulses(self, count: int = 3, on: float = 0.1, off: float = 0.1,
+                   gap: float = 1.0) -> None:
+        """Repeat a burst of `count` short pulses, then hold dark for `gap`.
+
+        Distinguishable at a glance from every other pattern (which are all
+        even-duty blinks): a burst-then-pause reads as "this device is faulty",
+        not as "this device is busy". Used for the hardware-error state, where
+        the LED is the only feedback an operator has while the grabette sits on
+        a bench with no screen.
+
+        The gap is slept in short slices so a state change (led_on/off/blink)
+        takes effect promptly instead of waiting out a full dark period.
+        """
+        def _pulse(stop: threading.Event) -> None:
+            while not stop.is_set():
+                for _ in range(max(1, count)):
+                    if stop.is_set():
+                        break
+                    self._led_request.set_value(self._led_pin, Value.ACTIVE)
+                    time.sleep(on)
+                    self._led_request.set_value(self._led_pin, Value.INACTIVE)
+                    time.sleep(off)
+                waited = 0.0
+                while waited < gap and not stop.is_set():
+                    time.sleep(min(0.05, gap - waited))
+                    waited += 0.05
+
+        self._start_pattern(_pulse)
+
+    def _start_pattern(self, target) -> None:
+        """Run target(stop_event) as THE blink thread, replacing any previous one.
+
+        Each thread gets its OWN stop Event, captured as an argument rather than
+        read off self: a pattern switch installs a fresh event, and a thread that
+        read the shared attribute would then poll the NEW (unset) one and never
+        exit — two threads would drive the same line and the pattern would be
+        neither. Joining the outgoing thread before starting the next one keeps
+        exactly one writer on the LED; the join is bounded so a wedged GPIO write
+        can't block the caller."""
+        prev, prev_stop = self._blink_thread, self._blink_stop
+        prev_stop.set()
+        if prev is not None and prev.is_alive():
+            prev.join(timeout=1.0)
+        stop = threading.Event()
+        self._blink_stop = stop
+        self._blink_thread = threading.Thread(target=target, args=(stop,), daemon=True)
         self._blink_thread.start()
 
     def is_pressed(self) -> bool:

--- a/packages/grabette/grabette/hardware/oakd.py
+++ b/packages/grabette/grabette/hardware/oakd.py
@@ -47,6 +47,19 @@ from .sync import SyncManager
 
 logger = logging.getLogger(__name__)
 
+
+class OakdCalibrationError(RuntimeError):
+    """The OAK-D's offline calibration could not be produced.
+
+    Fatal for recording, not merely for this device's live view: every episode
+    needs oakd_calib_offline.json to be convertible downstream, so a grabette
+    that can't produce one must refuse to record rather than fill its card with
+    data the SLAM pipeline will reject days later. Raised by init_device; the
+    backend turns it into a device-wide hardware error (see
+    RpiBackend.hardware_error) which blocks capture and drives the error LED.
+    """
+
+
 _MASK_PATH = Path(__file__).parent / "oak_mask.png"
 
 
@@ -155,7 +168,12 @@ class OakdCapture:
     # ------------------------------------------------------------------ init
 
     def init_device(self) -> None:
-        """Connect, read calibration, build pipeline, START it, launch drainers."""
+        """Connect, read calibration, build pipeline, START it, launch drainers.
+
+        Raises OakdCalibrationError if the offline calibration can't be produced
+        — recording without it yields unconvertible episodes, so the device must
+        not come up as if it were ready.
+        """
         import depthai as dai
 
         logger.info("Connecting to OAK-D for calibration read...")
@@ -308,6 +326,14 @@ class OakdCapture:
         Schema matches what grabette-data/docker/oak_vslam expects:
         width, height, fx, fy, cx, cy, baseline (m), imu_to_cam (4x4).
 
+        Raises OakdCalibrationError when the calibration can't be read or comes
+        back unusable. It used to log a warning and return {} — start_recording
+        then simply skipped writing oakd_calib_offline.json, and the whole
+        session's episodes reached the SLAM Space with "missing
+        oakd_calib_offline.json", hours after the data could still have been
+        re-recorded. This file is not optional: without it an episode can never
+        be converted, so failing to produce it is a hardware fault, not a
+        warning.
         """
         import depthai as dai
         try:
@@ -318,19 +344,31 @@ class OakdCapture:
             baseline_m = calib.getBaselineDistance(
                 dai.CameraBoardSocket.CAM_C, dai.CameraBoardSocket.CAM_B
             ) / 100.0
-            return {
-                "width": w,
-                "height": h,
-                "fx": intr[0][0],
-                "fy": intr[1][1],
-                "cx": intr[0][2],
-                "cy": intr[1][2],
-                "baseline": baseline_m,
-                "imu_to_cam": imu_extr,
-            }
         except Exception as e:
-            logger.warning("Could not extract OAK-D offline calib: %s", e)
-            return {}
+            raise OakdCalibrationError(
+                f"could not read the OAK-D calibration: {e or type(e).__name__}"
+            ) from e
+        calib_offline = {
+            "width": w,
+            "height": h,
+            "fx": intr[0][0],
+            "fy": intr[1][1],
+            "cx": intr[0][2],
+            "cy": intr[1][2],
+            "baseline": baseline_m,
+            "imu_to_cam": imu_extr,
+        }
+        # Same contract the offline pipeline checks (grabette_postprocess
+        # checks.recording._check_calib): a present-but-degenerate calibration is
+        # exactly as unusable as a missing one, so catch it here too rather than
+        # letting it through to produce episodes that fail conversion.
+        bad = [k for k in ("fx", "fy", "baseline") if not calib_offline[k] > 0]
+        if bad:
+            raise OakdCalibrationError(
+                "the OAK-D reported an unusable calibration "
+                f"({', '.join(f'{k}={calib_offline[k]}' for k in bad)})"
+            )
+        return calib_offline
 
     # ------------------------------------------------------ recording on/off
 
@@ -367,6 +405,16 @@ class OakdCapture:
             raise RuntimeError("OakdCapture already recording")
         if not self.sync.is_started:
             raise RuntimeError("SyncManager must be started before OakdCapture")
+        # Not a soft "write it if we have it": init_device refuses to come up
+        # without a usable offline calibration, so reaching here without one means
+        # that guard was bypassed. Refuse rather than silently produce an episode
+        # that could never be converted — checked before the episode dir is
+        # created so a refusal leaves nothing behind.
+        if not self._calib_offline:
+            raise OakdCalibrationError(
+                "no OAK-D offline calibration available — refusing to record an "
+                "episode that could never be converted"
+            )
 
         self._output_dir = Path(output_dir).absolute()
         self._output_dir.mkdir(parents=True, exist_ok=True)
@@ -380,10 +428,9 @@ class OakdCapture:
             (self._output_dir / "oakd_calib.json").write_text(
                 json.dumps(self._calibration_json, indent=2)
             )
-        if self._calib_offline:
-            (self._output_dir / "oakd_calib_offline.json").write_text(
-                json.dumps(self._calib_offline, indent=2)
-            )
+        (self._output_dir / "oakd_calib_offline.json").write_text(
+            json.dumps(self._calib_offline, indent=2)
+        )
         # Copy mask alongside the episode so downstream SLAM can mask mp4 frames
         # (we can't mask H.264-encoded streams in-flight).
         if self._mask is not None:

--- a/packages/grabette/grabette/hf.py
+++ b/packages/grabette/grabette/hf.py
@@ -3,9 +3,68 @@
 from __future__ import annotations
 
 import logging
+import threading
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# --- socket timeouts on every Hub call ----------------------------------------
+# huggingface_hub builds its httpx client with timeout=None — no connect, read or
+# write deadline at any layer. A link that DEGRADES rather than drops therefore
+# leaves an upload waiting on a socket that never delivers, forever, inside a
+# thread nothing can interrupt. That is the whole reason a grabette could stay
+# pinned as "uploading" until the fleet Space was restarted.
+#
+# These are per-SOCKET-OPERATION budgets, not deadlines for the whole transfer:
+# httpx counts them between chunks, so a legitimately slow multi-gigabyte upload
+# over a weak link keeps running as long as it keeps making progress, and only a
+# genuine stall trips them. When one does trip, it surfaces as
+# httpx.TimeoutException INSIDE the worker thread — which hf_hub's own
+# http_backoff already retries on, and which lets the thread DIE instead of
+# lingering. That distinction is the point: an abandoned upload thread is far
+# worse on a Pi than a slow one (see _UPLOAD_EXECUTOR in app/main.py).
+_HUB_CONNECT_TIMEOUT_S = 20.0
+_HUB_READ_TIMEOUT_S = 60.0
+_HUB_WRITE_TIMEOUT_S = 60.0   # no progress writing a chunk for this long = stalled
+_HUB_POOL_TIMEOUT_S = 20.0
+
+_client_factory_lock = threading.Lock()
+_client_factory_installed = False
+
+
+def install_hub_timeouts() -> None:
+    """Give every huggingface_hub call a socket timeout. Idempotent, best effort.
+
+    set_client_factory is process-wide and public API. Called from _get_api so it
+    covers every Hub user on the device (episode upload, SLAM push, whoami)
+    without each of them having to remember."""
+    global _client_factory_installed
+    with _client_factory_lock:
+        if _client_factory_installed:
+            return
+        try:
+            import httpx
+            from huggingface_hub import set_client_factory
+            from huggingface_hub.utils._http import hf_request_event_hook
+
+            timeout = httpx.Timeout(
+                connect=_HUB_CONNECT_TIMEOUT_S, read=_HUB_READ_TIMEOUT_S,
+                write=_HUB_WRITE_TIMEOUT_S, pool=_HUB_POOL_TIMEOUT_S,
+            )
+            set_client_factory(lambda: httpx.Client(
+                event_hooks={"request": [hf_request_event_hook]},
+                follow_redirects=True, timeout=timeout,
+            ))
+            logger.info("Hub client timeouts installed (connect=%.0fs read=%.0fs "
+                        "write=%.0fs)", _HUB_CONNECT_TIMEOUT_S, _HUB_READ_TIMEOUT_S,
+                        _HUB_WRITE_TIMEOUT_S)
+        except Exception as e:  # noqa: BLE001 — never block Hub access over this
+            # A future hf_hub could drop set_client_factory or move the event
+            # hook. Losing the timeouts is a regression, not an outage: uploads
+            # still work, they are just unbounded again (and app/main.py's own
+            # attempt bound remains the backstop).
+            logger.warning("Could not install Hub client timeouts: %s", e)
+        _client_factory_installed = True
 
 
 class HuggingFaceClient:
@@ -48,6 +107,7 @@ class HuggingFaceClient:
     def _get_api(self):
         from huggingface_hub import HfApi, get_token
 
+        install_hub_timeouts()
         token = get_token()
         if token != self._cached_token:
             self._api = None

--- a/packages/grabette/grabette/hf.py
+++ b/packages/grabette/grabette/hf.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -22,7 +23,13 @@ logger = logging.getLogger(__name__)
 # httpx.TimeoutException INSIDE the worker thread — which hf_hub's own
 # http_backoff already retries on, and which lets the thread DIE instead of
 # lingering. That distinction is the point: an abandoned upload thread is far
-# worse on a Pi than a slow one (see _UPLOAD_EXECUTOR in app/main.py).
+# worse on a Pi than a slow one (see _UPLOAD_WORKERS in app/main.py).
+#
+# Scope, and it is narrower than it looks: this covers what goes through httpx,
+# i.e. the JSON API and LFS uploads. A xet upload — the DEFAULT path, since
+# hf-xet is a hard dependency of huggingface_hub on aarch64 — moves its bytes in
+# a Rust stack that never touches this client, so none of these timeouts apply to
+# it. The heartbeat below is what watches that path.
 _HUB_CONNECT_TIMEOUT_S = 20.0
 _HUB_READ_TIMEOUT_S = 60.0
 _HUB_WRITE_TIMEOUT_S = 60.0   # no progress writing a chunk for this long = stalled
@@ -30,6 +37,228 @@ _HUB_POOL_TIMEOUT_S = 20.0
 
 _client_factory_lock = threading.Lock()
 _client_factory_installed = False
+
+
+# --- upload liveness heartbeat -------------------------------------------------
+# A total-elapsed bound on an upload cannot express what we need: whatever value
+# it takes, it encodes an assumed throughput, and a healthy upload on a slower
+# link gets killed. What we actually want to detect is SILENCE, so the bound has
+# to be on "no progress since", which a progressing upload can never trip however
+# long it legitimately runs.
+#
+# That needs a progress signal, and it needs one per upload path, because the two
+# paths do their I/O in different stacks and NEITHER source sees the other's
+# bytes:
+#   - xet (the default: hf-xet is a hard dependency of huggingface_hub on every
+#     machine we run on) does its HTTP in Rust, entirely OUTSIDE the httpx client
+#     below. The socket timeouts never see a single byte of it. Hooked at
+#     hf_xet.upload_files, which reports byte-level progress across both phases
+#     (local hashing, then transfer).
+#   - LFS and the plain JSON API go through get_session(), i.e. our httpx client,
+#     where request/response hooks mark each call. Intra-request silence there is
+#     already bounded by _HUB_READ/WRITE_TIMEOUT_S, so per-request marks suffice.
+#
+# Which path a given upload takes is decided SERVER-side (is this repo
+# xet-enabled), so we cannot know it in advance — hence heartbeat_is_complete()
+# demanding both before staleness may be trusted at all.
+#
+# ONE phase is observed by neither, and it is a deliberate accept rather than an
+# oversight: huggingface_hub sha256s every file locally in
+# CommitOperationAdd.__post_init__, before any network call, and nothing marks
+# during it. It is bounded by an argument rather than by a timeout — capture
+# itself sustains ~8 MB/s of writes for the whole recording (H.264 + lossless
+# FFV1 depth), so a card that could record an episode can re-read it at least
+# that fast. Hashing 3 GB at 8 MB/s is ~375s against a 900s stall budget, and
+# sequential reads beat concurrent multi-stream writes, so the real margin is
+# wider. A device too slow to clear that bar could not have produced the episode.
+#
+# Read by app/main.py's upload watchdog. Deliberately process-wide rather than
+# per-upload: the callback is invoked from Rust threads, so there is nothing to
+# key it on. The consequence is that unrelated Hub traffic (a whoami, a SLAM push,
+# an abandoned upload thread that resumes) can refresh the heartbeat and delay an
+# abandonment. That is the harmless direction — every residual imprecision here
+# makes us wait LONGER, never kill an upload that was fine.
+_activity_lock = threading.Lock()
+_last_activity = 0.0
+_heartbeat_sources: set[str] = set()
+_heartbeat_installed = False
+
+# The xet progress callback's parameter name, verified against the real signature
+# at install time rather than assumed — injecting into the wrong slot would pass a
+# function where the Rust side expects a repo type.
+_XET_PROGRESS_ARG = "progress_updater"
+
+# Every path must be observable before "it has gone quiet" means anything. A
+# PARTIAL heartbeat is worse than none: with only httpx wired, a xet transfer
+# emits no marks for its whole duration, and the watchdog would read that healthy
+# transfer as a stall and abandon it — the exact failure this design exists to
+# prevent.
+_REQUIRED_SOURCES = frozenset({"xet", "httpx"})
+
+
+def note_hub_activity() -> None:
+    """Mark "the Hub link just did something". Cheap: one lock, one clock read."""
+    global _last_activity
+    with _activity_lock:
+        _last_activity = time.monotonic()
+
+
+def hub_activity_age_s() -> float | None:
+    """Seconds since the last observed Hub I/O, or None if never marked."""
+    with _activity_lock:
+        if _last_activity == 0.0:
+            return None
+        return time.monotonic() - _last_activity
+
+
+def heartbeat_sources() -> frozenset[str]:
+    """Which progress sources are actually wired."""
+    with _activity_lock:
+        return frozenset(_heartbeat_sources)
+
+
+def heartbeat_is_complete() -> bool:
+    """True when every upload path is observable, so silence can be trusted.
+
+    False means a watchdog must NOT conclude anything from staleness — see
+    _UPLOAD_BLIND_ATTEMPT_TIMEOUT_S in app/main.py.
+    """
+    return _REQUIRED_SOURCES <= heartbeat_sources()
+
+
+def _add_source(name: str) -> None:
+    with _activity_lock:
+        _heartbeat_sources.add(name)
+
+
+# Fields on hf_xet's total-progress payload that say how much moved since the
+# last tick. The first covers local hashing/chunking, the second the transfer, so
+# together they span both phases of an upload.
+_XET_INCREMENTS = ("total_bytes_completion_increment",
+                   "total_transfer_bytes_completion_increment")
+
+
+def _progress_moved(args) -> bool:
+    """True if this progress tick reports real advancement.
+
+    Marking on the mere ARRIVAL of a tick would make the heartbeat mean "the
+    library is still talking" rather than "bytes are still moving". hf_xet ticks
+    on a timer — it reports a completion RATE, which needs one — so a wedged
+    transfer keeps ticking, and a heartbeat fed by arrivals would call it alive
+    forever. That is the original bug, reintroduced one layer up.
+
+    An unrecognised payload marks anyway. The two mistakes are not equal: failing
+    to spot a hang costs a device held until the blind bound, while wrongly
+    withholding a mark kills an upload that was fine. Only the first is
+    acceptable.
+    """
+    total = args[0] if args else None
+    known = [v for v in (getattr(total, n, None) for n in _XET_INCREMENTS)
+             if isinstance(v, (int, float)) and not isinstance(v, bool)]
+    if not known:
+        return True
+    return any(v > 0 for v in known)
+
+
+def _marking_updater(inner):
+    """A xet progress callback that marks the heartbeat, then defers to `inner`.
+
+    `inner` is None whenever HF progress bars are off, because huggingface_hub
+    then builds no reporter and passes None — still passing the argument. Chaining
+    onto None is therefore what makes this work with progress bars disabled, which
+    is the difference between a heartbeat that survives a quiet journald and one
+    that does not.
+    """
+    def updater(*args, **kwargs):
+        if _progress_moved(args):
+            note_hub_activity()
+        if inner is not None:
+            return inner(*args, **kwargs)
+        return None
+    return updater
+
+
+def _xet_progress_index(fn) -> int | None:
+    """Position of the progress callback in fn's signature, or None if unknown."""
+    import inspect
+
+    try:
+        params = list(inspect.signature(fn).parameters)
+    except (TypeError, ValueError):
+        return None
+    return params.index(_XET_PROGRESS_ARG) if _XET_PROGRESS_ARG in params else None
+
+
+def _wrap_xet_upload(fn, index: int):
+    """fn with the heartbeat chained onto whatever progress callback it is given."""
+    def call(*args, **kwargs):
+        if len(args) > index:
+            args = args[:index] + (_marking_updater(args[index]),) + args[index + 1:]
+        elif _XET_PROGRESS_ARG in kwargs:
+            kwargs[_XET_PROGRESS_ARG] = _marking_updater(kwargs[_XET_PROGRESS_ARG])
+        else:
+            # Called in a shape we do not recognise. Uploading matters more than
+            # observing it, so pass it straight through.
+            logger.warning("xet upload called without a progress argument — "
+                           "this upload is not observable")
+        return fn(*args, **kwargs)
+
+    call._grabette_heartbeat = True
+    return call
+
+
+def _install_xet_heartbeat() -> bool:
+    """Mark the heartbeat from hf_xet's progress callback. True if wired.
+
+    Hooked at hf_xet rather than at huggingface_hub's XetProgressReporter, even
+    though the reporter looks like the more natural seam. Two reasons, both about
+    not going blind: the reporter is only CONSTRUCTED when progress bars are
+    enabled, so wrapping it ties the watchdog to a display setting anyone could
+    switch off; and huggingface_hub imports these two functions inside its upload
+    function, so replacing the attributes here is picked up on the next upload.
+    """
+    try:
+        import hf_xet
+    except Exception as e:  # noqa: BLE001
+        logger.warning("No xet upload heartbeat (%s)", e)
+        return False
+    wired = False
+    for name in ("upload_files", "upload_bytes"):
+        fn = getattr(hf_xet, name, None)
+        if fn is None:
+            logger.warning("No xet heartbeat on hf_xet.%s: it is gone", name)
+            continue
+        if getattr(fn, "_grabette_heartbeat", False):
+            wired = True
+            continue
+        index = _xet_progress_index(fn)
+        if index is None:
+            logger.warning("No xet heartbeat on hf_xet.%s: no %r in its signature",
+                           name, _XET_PROGRESS_ARG)
+            continue
+        setattr(hf_xet, name, _wrap_xet_upload(fn, index))
+        wired = True
+    return wired
+
+
+def install_upload_heartbeat() -> None:
+    """Wire every available progress source. Idempotent, best effort."""
+    global _heartbeat_installed
+    if _heartbeat_installed:
+        return
+    if _install_xet_heartbeat():
+        _add_source("xet")
+    _heartbeat_installed = True
+    if heartbeat_is_complete():
+        logger.info("Upload heartbeat complete (%s)",
+                    ", ".join(sorted(heartbeat_sources())))
+    else:
+        # Not cosmetic: this is the line that explains, after the fact, why an
+        # upload was bounded by elapsed time instead of by silence.
+        logger.error("Upload heartbeat INCOMPLETE — have {%s}, need {%s}. Upload "
+                     "stalls can only be caught by the blind fallback bound.",
+                     ", ".join(sorted(heartbeat_sources())) or "nothing",
+                     ", ".join(sorted(_REQUIRED_SOURCES)))
 
 
 def install_hub_timeouts() -> None:
@@ -51,10 +280,19 @@ def install_hub_timeouts() -> None:
                 connect=_HUB_CONNECT_TIMEOUT_S, read=_HUB_READ_TIMEOUT_S,
                 write=_HUB_WRITE_TIMEOUT_S, pool=_HUB_POOL_TIMEOUT_S,
             )
+            # Marking on BOTH request and response, not just one: a request hook
+            # fires before a call that may then block for its whole read timeout,
+            # so on its own it would let a 60s stall look like fresh activity for
+            # those 60s. The pair brackets the call instead.
+            def _mark(_r) -> None:
+                note_hub_activity()
+
             set_client_factory(lambda: httpx.Client(
-                event_hooks={"request": [hf_request_event_hook]},
+                event_hooks={"request": [hf_request_event_hook, _mark],
+                             "response": [_mark]},
                 follow_redirects=True, timeout=timeout,
             ))
+            _add_source("httpx")
             logger.info("Hub client timeouts installed (connect=%.0fs read=%.0fs "
                         "write=%.0fs)", _HUB_CONNECT_TIMEOUT_S, _HUB_READ_TIMEOUT_S,
                         _HUB_WRITE_TIMEOUT_S)
@@ -108,6 +346,7 @@ class HuggingFaceClient:
         from huggingface_hub import HfApi, get_token
 
         install_hub_timeouts()
+        install_upload_heartbeat()
         token = get_token()
         if token != self._cached_token:
             self._api = None

--- a/packages/grabette/grabette/hf.py
+++ b/packages/grabette/grabette/hf.py
@@ -138,7 +138,7 @@ _XET_INCREMENTS = ("total_bytes_completion_increment",
                    "total_transfer_bytes_completion_increment")
 
 
-def _progress_moved(args) -> bool:
+def _progress_moved(total_update) -> bool:
     """True if this progress tick reports real advancement.
 
     Marking on the mere ARRIVAL of a tick would make the heartbeat mean "the
@@ -152,8 +152,7 @@ def _progress_moved(args) -> bool:
     withholding a mark kills an upload that was fine. Only the first is
     acceptable.
     """
-    total = args[0] if args else None
-    known = [v for v in (getattr(total, n, None) for n in _XET_INCREMENTS)
+    known = [v for v in (getattr(total_update, n, None) for n in _XET_INCREMENTS)
              if isinstance(v, (int, float)) and not isinstance(v, bool)]
     if not known:
         return True
@@ -168,12 +167,19 @@ def _marking_updater(inner):
     onto None is therefore what makes this work with progress bars disabled, which
     is the difference between a heartbeat that survives a quiet journald and one
     that does not.
+
+    The parameter names are part of the contract, not a style choice. hf_xet
+    inspects this callable and accepts only two shapes: one parameter of any
+    name, or exactly two named (total_update, item_updates). A `*args, **kwargs`
+    wrapper reads as two parameters named "args" and "kwargs", so hf_xet raises
+    before a byte moves and every attempt fails identically — which is worse than
+    no heartbeat at all. `fake_xet` in the tests enforces the same rule.
     """
-    def updater(*args, **kwargs):
-        if _progress_moved(args):
+    def updater(total_update, item_updates):
+        if _progress_moved(total_update):
             note_hub_activity()
         if inner is not None:
-            return inner(*args, **kwargs)
+            return inner(total_update, item_updates)
         return None
     return updater
 

--- a/packages/grabette/grabette/models.py
+++ b/packages/grabette/grabette/models.py
@@ -23,6 +23,11 @@ class CaptureStatus(BaseModel):
     frame_count: int = 0
     imu_sample_count: int = 0
     angle_sample_count: int = 0
+    # Why a capture cannot start right now ("" = it can). Rides on the status the
+    # dashboard already polls, so a device tied up by an upload reads as busy
+    # instead of "Idle" — a device that looks free while it is not is how a
+    # recording gets started on top of one.
+    blocked_reason: str = ""
 
 
 class SensorState(BaseModel):

--- a/packages/grabette/grabette/output.py
+++ b/packages/grabette/grabette/output.py
@@ -4,8 +4,29 @@ Ported from grabette-capture/grabette_capture/output.py.
 """
 
 import json
+import os
 from pathlib import Path
 from typing import TypedDict
+
+
+def write_json_atomic(path: Path, payload) -> None:
+    """Write `payload` as JSON so the file is never observed half-written.
+
+    A plain write_text() truncates the target on open, so an interruption
+    between that and the flush — power cut on the Pi, SD card full — leaves a
+    file that EXISTS but is empty. metadata.json is written last precisely so
+    that its presence means "episode fully saved", and a non-atomic write broke
+    that promise: a 0-byte metadata.json read back as a JSONDecodeError that
+    500'd GET /api/tasks and blanked the whole dashboard. Writing to a sibling
+    temp file and renaming makes the swap atomic on POSIX, so the reader sees
+    either no file or a complete one.
+    """
+    tmp = path.with_name(path.name + ".tmp")
+    with open(tmp, "w") as f:
+        json.dump(payload, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
 
 
 class IMUSampleDict(TypedDict):

--- a/packages/grabette/grabette/relay_client.py
+++ b/packages/grabette/grabette/relay_client.py
@@ -52,6 +52,11 @@ _BATTERY_INTERVAL_S = 30.0
 # command types here that do no hardware work and return fast.
 _FAST_PATH_TYPES = frozenset({"cancel_dataset"})
 
+# Hardware-fault text is reported on the heartbeat, i.e. in a query string. The
+# messages name the fault, the consequence and the fix, so they are a sentence or
+# two — long enough to be worth capping, short enough that the cap never bites.
+_FAULT_MAX_CHARS = 300
+
 logger = logging.getLogger("grabette.relay_client")
 
 CommandHandler = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
@@ -119,6 +124,14 @@ class RelayClient:
         # recording while the device is busy. In-memory & fast (unlike battery's
         # I2C), so it's read inline on the heartbeat path.
         activity_provider: Optional[Callable[[], Optional[str]]] = None,
+        # Optional callable returning why this device is in a HARDWARE FAULT —
+        # a state where it refuses to record because every episode would be
+        # unconvertible (no OAK-D calibration, no angle sensors) — or "" when
+        # healthy. A separate channel from activity on purpose: the two are
+        # orthogonal (a faulted device can also be uploading), and folding a
+        # fault into the activity enum would have made it invisible to a fleet
+        # that only knows the four activity values.
+        fault_provider: Optional[Callable[[], Optional[str]]] = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.token_provider = token_provider
@@ -132,6 +145,7 @@ class RelayClient:
         self.unassigned_provider = unassigned_provider
         self.tasks_rev_provider = tasks_rev_provider
         self.activity_provider = activity_provider
+        self.fault_provider = fault_provider
         self._last_reported_rev: Optional[int] = None  # last task revision sent to the fleet
         self._battery: Optional[float] = None  # cached; refreshed off the heartbeat path
         self.status = "offline"
@@ -274,6 +288,16 @@ class RelayClient:
                             act = None
                         if act:
                             params["status"] = act
+                    if self.fault_provider is not None:  # in-memory, safe inline
+                        try:
+                            fault = self.fault_provider()
+                        except Exception:
+                            fault = None
+                        # Sent on EVERY beat, empty included: the fleet must learn
+                        # that a fault cleared as promptly as it learned of it, and
+                        # a field that only appears when broken can never say
+                        # "fixed". Truncated because it rides in a query string.
+                        params["error"] = (fault or "")[:_FAULT_MAX_CHARS]
                     try:
                         async with session.post(
                             f"{self.base_url}/api/devices/heartbeat",

--- a/packages/grabette/grabette/replay.py
+++ b/packages/grabette/grabette/replay.py
@@ -53,11 +53,16 @@ class ReplayEngine:
 
         # Load duration from metadata
         meta_path = path / "metadata.json"
+        meta = {}
         if meta_path.exists():
-            meta = json.loads(meta_path.read_text())
-            self._duration_ms = meta.get("duration_seconds", 0) * 1000
-        else:
-            self._duration_ms = 0
+            # Same tolerance as TaskManager._get_episode_info: an episode whose
+            # metadata was truncated by an interrupted write still has its video
+            # and IMU, so replay it at duration 0 rather than raising.
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (OSError, ValueError) as e:
+                logger.warning("Unreadable metadata for replay of %s: %s", path, e)
+        self._duration_ms = meta.get("duration_seconds", 0) * 1000
 
         self._imu_samples = []
         self._angle_samples = []

--- a/packages/grabette/grabette/task.py
+++ b/packages/grabette/grabette/task.py
@@ -84,6 +84,10 @@ class EpisodeInfo(BaseModel):
     angle_sample_count: int = 0
     has_video: bool = False
     has_imu: bool = False
+    # False when metadata.json is missing or unreadable. The episode is still
+    # listed (its files are on disk and may be recoverable), but its counters
+    # are zeros rather than facts, and the UI must not present them as facts.
+    metadata_ok: bool = True
 
 
 class TaskInfo(BaseModel):
@@ -459,13 +463,28 @@ class TaskManager:
         frame_count = 0
         imu_sample_count = 0
         angle_sample_count = 0
+        metadata_ok = True
         meta_path = ep_dir / "metadata.json"
         if meta_path.exists():
-            meta = json.loads(meta_path.read_text())
+            # One unreadable episode must never take the whole listing down with
+            # it. This runs once per episode of every task, so an exception here
+            # used to 500 GET /api/tasks — and the dashboard, which cannot tell
+            # a failed call from an empty one, then showed NO tasks at all while
+            # the fleet (which reports from the registry, not from these files)
+            # still showed them. A 0-byte metadata.json from an interrupted
+            # write was enough to do it.
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (OSError, ValueError) as e:
+                logger.warning("Unreadable metadata for episode %s (%s): %s",
+                               episode_id, meta_path, e)
+                meta, metadata_ok = {}, False
             duration = meta.get("duration_seconds", 0.0)
             frame_count = meta.get("frame_count", 0)
             imu_sample_count = meta.get("imu_sample_count") or meta.get("oakd", {}).get("imu_samples", 0)
             angle_sample_count = meta.get("angle_sample_count", 0)
+        else:
+            metadata_ok = False
 
         return EpisodeInfo(
             episode_id=episode_id,
@@ -476,6 +495,7 @@ class TaskManager:
             angle_sample_count=angle_sample_count,
             has_video=video_path.exists(),
             has_imu=imu_present,
+            metadata_ok=metadata_ok,
         )
 
     def revision(self) -> int:

--- a/packages/grabette/grabette/ui/api_client.py
+++ b/packages/grabette/grabette/ui/api_client.py
@@ -185,11 +185,20 @@ class GrabetteClient:
     # -- Tasks --
 
     def list_tasks(self) -> list[dict]:
+        """Every task on the device, or [] if the call failed.
+
+        The empty list is NOT ambiguous to a caller who knows the API: the
+        device always has at least Unassigned, so [] can only mean this call
+        failed. It used to fail SILENTLY — no log, no message — which is how a
+        single unreadable episode (500 on /api/tasks) turned into a dashboard
+        showing no tasks and no episodes with nothing anywhere to explain it.
+        """
         try:
             r = self._http.get("/api/tasks")
             r.raise_for_status()
             return r.json()
-        except Exception:
+        except Exception as e:  # noqa: BLE001 — the UI must not die with the call
+            logger.warning("Could not list tasks from %s: %s", self.base_url, e)
             return []
 
     # -- Episodes --

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -471,6 +471,10 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
         rows = []
         task_name = ""
         task_description = ""
+        # The device always has Unassigned, so an empty list means the API call
+        # failed — never that there is nothing to show. Saying so beats a blank
+        # page that looks exactly like "no episodes recorded yet".
+        api_down = not sessions
         for s in sessions:
             if s["id"] == session_id:
                 task_name = s.get("name", "")
@@ -497,9 +501,16 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
         count_str = f"{count} episode" + ("s" if count != 1 else "")
         ep_title = f"## Episodes for *{task_name}*" if task_name else "## Episodes"
         desc_parts = []
+        if api_down:
+            desc_parts.append(
+                "⚠️ **Could not reach the grabette API** — the task list below is "
+                "empty because the call failed, not because there is nothing "
+                "recorded. Check the daemon log for the error."
+            )
         if task_description:
             desc_parts.append(f"**Task description:** {task_description}")
-        desc_parts.append(f"*{count_str} recorded*")
+        if not api_down:
+            desc_parts.append(f"*{count_str} recorded*")
         desc = "\n\n".join(desc_parts)
         return rows, move_dd, task_header, desc, cap_title, ep_title
 

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import io
 import logging
 import math
@@ -206,10 +207,14 @@ def _status_bar_html(sys_info, oakd_status, cam_status):
     ORANGE = ("#f97316", "#9a3412")
     RED = ("#ef4444", "#991b1b")
 
-    def _badge(label, value, colors):
+    def _badge(label, value, colors, title=""):
         value_color, border_color = colors
+        # `title` carries the long form (a hardware fault's full explanation) as
+        # a hover tooltip: the badge row has one line per badge and truncates,
+        # so a message that matters can't live in the value itself.
+        tip = f" title=\"{html.escape(title, quote=True)}\"" if title else ""
         return (
-            f"<div style='background:#1e293b;border-radius:8px;padding:0.55rem 1rem;"
+            f"<div{tip} style='background:#1e293b;border-radius:8px;padding:0.55rem 1rem;"
             f"border:2px solid {border_color};flex:1;min-width:0;'>"
             f"<div style='font-size:0.65rem;text-transform:uppercase;letter-spacing:0.09em;"
             f"color:#94a3b8;margin-bottom:0.2rem;'>{label}</div>"
@@ -239,9 +244,14 @@ def _status_bar_html(sys_info, oakd_status, cam_status):
     else:
         rgb_badge = _badge("RGB Camera", "Disconnected", RED)
 
-    # OAK-D (4-state: connected / starting / off / error; N/A when unsupported)
+    # OAK-D (5-state: fault / connected / starting / off / error; N/A when
+    # unsupported). The fault comes FIRST: it is the one state where the device
+    # refuses to record, so it must not be masked by "Off" after a power-down.
     if not oakd_status or not oakd_status.get("supported"):
         oakd_badge = _badge("OAK-D", "N/A", GRAY)
+    elif oakd_status.get("hardware_error"):
+        oakd_badge = _badge("OAK-D", "Cannot record", RED,
+                            title=oakd_status["hardware_error"])
     elif oakd_status.get("initialized"):
         oakd_badge = _badge("OAK-D", "Connected", GREEN)
     elif oakd_status.get("initializing"):
@@ -360,6 +370,12 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
             if cap.get("angle_sample_count", 0):
                 parts[-1] += f"  |  Angle: {cap['angle_sample_count']}"
             return "\n".join(parts)
+        # Not capturing is not the same as free. A device tied up by an upload
+        # (or held back by a hardware fault) used to read "○ Idle" here, which is
+        # precisely the reading that gets a recording started on top of one.
+        blocked = cap.get("blocked_reason") or ""
+        if blocked:
+            return f"⛔ Cannot record — {blocked}"
         return "○ Idle"
 
     def on_toggle_capture(session_id):

--- a/packages/grabette/pyproject.toml
+++ b/packages/grabette/pyproject.toml
@@ -26,9 +26,17 @@ rpi = [
     # and on recent Pi OS Bookworm aarch64 + cpython 3.11.15 there's no wheel,
     # so uv builds from source for ~30 min. Don't.
     "depthai>=3.6,<4",
-    "opencv-python-headless>=4.8",
+    "grabette[vision]",
     "scipy",  # quaternion + rotation math (teleop, dataset processing)
     "rerun-sdk",  # live trajectory visualization for teleop
+]
+# The host-installable half of the OAK-D stack. Split out of `rpi` because that
+# extra is unusable off a Pi (picamera2, depthai, gpiod), yet grabette.hardware.oakd
+# imports cv2 at module level — so CI could not import the module it tests, and
+# test_hardware_error.py failed collection on every run. This is a feature set,
+# not test tooling: it stays out of the `test` extra on purpose.
+vision = [
+    "opencv-python-headless>=4.8",
 ]
 hf = [
     "huggingface-hub>=0.20.0",

--- a/packages/grabette/tests/test_atomic_metadata.py
+++ b/packages/grabette/tests/test_atomic_metadata.py
@@ -1,0 +1,52 @@
+"""metadata.json must never be observed empty or half-written.
+
+The episode writer puts metadata.json LAST so that its presence means "this
+episode is fully saved". A plain write_text() truncates the target on open, so
+an interrupted write — power cut on the Pi, SD card full — left a file that
+existed but was empty. Reading it back raised, which 500'd GET /api/tasks and
+blanked the device dashboard of every task while the fleet still showed them.
+"""
+import json
+
+import pytest
+
+from grabette.output import write_json_atomic
+
+
+def test_it_writes_readable_json_and_leaves_no_temp_file(tmp_path):
+    target = tmp_path / "metadata.json"
+
+    write_json_atomic(target, {"duration_seconds": 4.0})
+
+    assert json.loads(target.read_text()) == {"duration_seconds": 4.0}
+    assert list(tmp_path.iterdir()) == [target], "a .tmp file was left behind"
+
+
+def test_a_failed_write_leaves_the_previous_file_intact(monkeypatch, tmp_path):
+    # The case that matters: the reader must see the OLD complete file or none —
+    # never the 0-byte truncation that a plain write_text() produces here.
+    target = tmp_path / "metadata.json"
+    write_json_atomic(target, {"duration_seconds": 4.0})
+
+    def boom(*a, **k):
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(json, "dump", boom)
+
+    with pytest.raises(OSError):
+        write_json_atomic(target, {"duration_seconds": 9.0})
+
+    assert json.loads(target.read_text()) == {"duration_seconds": 4.0}
+
+
+def test_the_backends_write_metadata_through_it(tmp_path):
+    # Both backends must go through the atomic writer — a direct write_text on
+    # metadata.json anywhere reintroduces the truncation window.
+    from pathlib import Path
+    import grabette.backend.mock as mock
+    import grabette.backend.rpi as rpi
+
+    for mod in (mock, rpi):
+        src = Path(mod.__file__).read_text()
+        assert 'write_json_atomic(episode_dir / "metadata.json"' in src
+        assert '"metadata.json").write_text' not in src, f"{mod.__name__} truncates"

--- a/packages/grabette/tests/test_capture_gate.py
+++ b/packages/grabette/tests/test_capture_gate.py
@@ -17,7 +17,6 @@ Two holes made that insufficient, and both are closed here:
 """
 import asyncio
 import sys
-import threading
 import types
 
 import pytest

--- a/packages/grabette/tests/test_capture_gate.py
+++ b/packages/grabette/tests/test_capture_gate.py
@@ -1,0 +1,261 @@
+"""A busy grabette must refuse to record, and must look busy.
+
+Starting a recording on top of dataset work does not fail loudly — it produces
+an episode. A worse one: hf_xet chunks and hashes in native threads, so an
+upload competes for CPU with the H.264 encoders and the OAK-D drainers, and the
+take comes back with dropped frames and jittered timestamps. An episode that
+looks recorded and is quietly degraded is the most expensive kind.
+
+The fleet already refused to dispatch a start to a device it knew was uploading.
+Two holes made that insufficient, and both are closed here:
+
+  * the PHYSICAL BUTTON and the local dashboard never consulted the fleet, so
+    they walked straight past that gate;
+  * the device could not see fleet-dispatched work at all — a relay command
+    creates no local job, so the heartbeat reported "idle" through a 20-minute
+    upload, and the fleet's own view was only as good as its command queue.
+"""
+import asyncio
+import sys
+import threading
+import types
+
+import pytest
+
+from grabette.app import main
+from grabette.backend.base import Backend
+
+
+@pytest.fixture(autouse=True)
+def _clean_activity():
+    main._active_dataset_work.clear()
+    main._stalled_uploads = 0
+    yield
+    main._active_dataset_work.clear()
+    main._stalled_uploads = 0
+
+
+# --- one answer to "what is this device doing" -------------------------------
+
+def test_idle_device_is_free():
+    assert main._device_activity() == "idle"
+    assert main._busy_reason() == ""
+
+
+def test_relay_dataset_work_is_visible_to_the_device_itself():
+    # The blind spot: relay commands create no local job, so this used to read
+    # "idle" for the whole upload — to the fleet AND to the capture gate.
+    main._active_dataset_work["cmd1"] = "uploading"
+    assert main._device_activity() == "uploading"
+
+    main._active_dataset_work["cmd1"] = "processing"
+    assert main._device_activity() == "processing"
+
+
+def test_processing_wins_over_uploading():
+    main._active_dataset_work.update({"a": "uploading", "b": "processing"})
+
+    assert main._device_activity() == "processing"
+
+
+def test_an_abandoned_upload_thread_still_counts_as_busy():
+    # We stopped waiting on it; it did not stop running. On a Pi it is hashing,
+    # not sleeping on a socket — the device is not free.
+    main._stalled_uploads = 1
+
+    assert main._device_activity() == "uploading"
+    assert "upload" in main._busy_reason()
+
+
+def test_the_upload_command_marks_the_device_busy_while_it_runs():
+    # End-to-end through the relay entry point: what the handler does is
+    # irrelevant, what matters is that the device reads as busy for its duration
+    # and free again straight after — including on an early error return.
+    seen = []
+
+    async def _fake_dispatch(cmd):
+        seen.append(main._device_activity())
+        return {"status": "error", "message": "whatever"}
+
+    orig = main._dispatch_relay_command
+    main._dispatch_relay_command = _fake_dispatch
+    try:
+        asyncio.run(main._handle_relay_command(
+            {"id": "c1", "type": "upload_episodes", "args": {}}))
+    finally:
+        main._dispatch_relay_command = orig
+
+    assert seen == ["uploading"]
+    assert main._device_activity() == "idle", "the finally must always release it"
+
+
+def test_an_unrelated_command_does_not_mark_the_device_busy():
+    seen = []
+
+    async def _fake_dispatch(cmd):
+        seen.append(main._device_activity())
+        return {"status": "ok"}
+
+    orig = main._dispatch_relay_command
+    main._dispatch_relay_command = _fake_dispatch
+    try:
+        asyncio.run(main._handle_relay_command({"id": "c1", "type": "get_state"}))
+    finally:
+        main._dispatch_relay_command = orig
+
+    assert seen == ["idle"]
+
+
+def test_capturing_is_not_a_blocker():
+    # start_capture has its own, clearer "Already capturing" error; reporting a
+    # recording as "busy" here would mask it.
+    assert main._RECORDING_BLOCKERS.get("capturing") is None
+
+
+# --- the gate itself ----------------------------------------------------------
+
+class _Backend(Backend):
+    """Minimal concrete Backend — only the gate is under test."""
+
+    async def start(self): ...
+    async def stop(self): ...
+    def get_state(self): ...
+    async def start_capture(self, episode_dir): self.raise_if_capture_blocked()
+    async def stop_capture(self): ...
+    def get_capture_status(self): ...
+    @property
+    def is_capturing(self): return False
+    def get_frame_jpeg(self): return None
+
+
+def test_no_probe_means_free():
+    # A backend nobody installed a probe on must record normally.
+    assert _Backend().busy_reason == ""
+    _Backend().raise_if_capture_blocked()
+
+
+def test_the_gate_refuses_while_busy():
+    b = _Backend()
+    b.set_busy_probe(lambda: "uploading episodes")
+
+    with pytest.raises(RuntimeError, match="uploading episodes"):
+        b.raise_if_capture_blocked()
+
+
+def test_start_capture_refuses_while_busy():
+    b = _Backend()
+    b.set_busy_probe(lambda: "uploading episodes")
+
+    with pytest.raises(RuntimeError, match="uploading episodes"):
+        asyncio.run(b.start_capture("/tmp/ep"))
+
+
+def test_a_broken_probe_never_blocks_recording():
+    # The probe is a diagnostic. If it throws, the failure mode must be "record
+    # anyway", not "this grabette can no longer record".
+    b = _Backend()
+    b.set_busy_probe(lambda: 1 / 0)
+
+    assert b.busy_reason == ""
+    b.raise_if_capture_blocked()
+
+
+def test_a_hardware_fault_outranks_a_busy_state():
+    # Both refuse, but the operator needs the actionable one: busy clears by
+    # itself, a fault does not.
+    class _Faulty(_Backend):
+        hardware_error = "no OAK-D calibration"
+
+    b = _Faulty()
+    b.set_busy_probe(lambda: "uploading episodes")
+
+    with pytest.raises(RuntimeError, match="calibration"):
+        b.raise_if_capture_blocked()
+
+
+def test_the_scheduler_refuses_up_front():
+    # A group start must fail at the press, not silently in a background task
+    # seconds later at T0.
+    from grabette.capture_scheduler import CaptureScheduler
+
+    b = _Backend()
+    b.set_busy_probe(lambda: "uploading episodes")
+
+    async def _go():
+        await CaptureScheduler().schedule(b, None, "/tmp/ep", None)
+
+    with pytest.raises(RuntimeError, match="uploading episodes"):
+        asyncio.run(_go())
+
+
+def test_a_free_device_schedules_normally():
+    from grabette.capture_scheduler import CaptureScheduler
+
+    async def _go():
+        s = CaptureScheduler()
+        await s.schedule(_Backend(), None, "/tmp/ep", None)
+        assert s.is_scheduled()
+        s._task.cancel()
+
+    asyncio.run(_go())
+
+
+# --- and it must LOOK busy ----------------------------------------------------
+
+if "gpiod" not in sys.modules:  # pragma: no cover - import shim, see test_hardware_error
+    _line = types.SimpleNamespace(
+        Bias=types.SimpleNamespace(PULL_UP="pull_up"),
+        Direction=types.SimpleNamespace(OUTPUT="out", INPUT="in"),
+        Value=types.SimpleNamespace(ACTIVE="active", INACTIVE="inactive"),
+    )
+    gpiod = types.ModuleType("gpiod")
+    gpiod.line = _line
+    gpiod.LineSettings = lambda **kw: kw
+    gpiod.request_lines = lambda *a, **kw: None
+    sys.modules["gpiod"] = gpiod
+    sys.modules["gpiod.line"] = _line
+
+
+class _LedBackend:
+    is_teleop_active = False
+    is_teleop_sending = False
+    is_stopping = False
+    is_starting = False
+    is_capturing = False
+    hardware_error = ""
+    busy_reason = ""
+
+
+def _desired(**state):
+    from grabette.button_listener import ButtonListener
+
+    b = _LedBackend()
+    for k, v in state.items():
+        setattr(b, k, v)
+    return ButtonListener(b, None)._desired_led()
+
+
+def test_a_busy_device_does_not_look_idle():
+    # Dark is the signal for "available" — an operator picks it up and presses.
+    assert _desired() == "off"
+    assert _desired(busy_reason="uploading episodes") == "busy"
+
+
+def test_a_running_capture_outranks_busy():
+    # If a recording IS somehow live, showing it wins.
+    assert _desired(busy_reason="uploading", is_capturing=True) == "on"
+    assert _desired(busy_reason="uploading", is_stopping=True) == "blink_fast"
+
+
+def test_a_fault_outranks_busy_on_the_led_too():
+    assert _desired(busy_reason="uploading", hardware_error="boom") == "error"
+
+
+def test_busy_and_error_patterns_are_distinguishable():
+    from grabette import button_listener as bl
+
+    # Same burst family, different count — "count the blips" only works if the
+    # counts differ and the gap is long enough to separate the bursts.
+    assert bl._BUSY_PULSES != bl._ERROR_PULSES
+    assert bl._BUSY_GAP_S >= bl._ERROR_GAP_S
+    assert bl._ERROR_GAP_S > bl._ERROR_PULSE_OFF_S * 4

--- a/packages/grabette/tests/test_dataset_commands.py
+++ b/packages/grabette/tests/test_dataset_commands.py
@@ -1,0 +1,407 @@
+"""Relay dataset commands: upload_episodes + the Space result the fleet trusts.
+
+Both incidents these cover were reported from the field:
+
+  1. A conversion where every episode lacked oakd_calib_offline.json finished as
+     "done" with no dataset. The device reported it as a success with no
+     result_url, the fleet filled the blank with a guessed repo URL, and the
+     operator got a green "Open <dataset>" link onto a 404.
+
+  2. An upload over a degraded link never came back. The command stayed in the
+     fleet's queue for that device, which therefore read as "uploading" to every
+     operator, through reboots, until the fleet Space itself was restarted.
+
+So: a Space that pushed nothing must be an error, and an upload attempt must be
+bounded and retried rather than allowed to hang.
+"""
+import asyncio
+import threading
+import time
+
+import pytest
+
+from grabette.app import main
+
+
+# --- 1. the Space said "done" but pushed nothing -----------------------------
+
+def test_quality_summary_names_the_dominant_reason():
+    quality = [
+        {"name": "a", "errors": ["missing oakd_calib_offline.json"]},
+        {"name": "b", "errors": ["missing oakd_calib_offline.json"]},
+        {"name": "c", "errors": ["SLAM failed: no trajectory produced"]},
+    ]
+
+    summary = main._space_quality_summary(quality)
+
+    # Counted, not listed, and the most frequent reason leads.
+    assert summary.startswith("missing oakd_calib_offline.json (2 episode(s))")
+    assert "SLAM failed: no trajectory produced (1 episode(s))" in summary
+
+
+def test_quality_summary_tolerates_junk():
+    # The Space's payload is data from another service; a shape change must not
+    # turn a reportable failure into an exception inside the error path.
+    assert main._space_quality_summary(None) == ""
+    assert main._space_quality_summary([]) == ""
+    assert main._space_quality_summary(["nope", {"errors": []}]) == ""
+
+
+def _process_result(status_payload):
+    """Drive process_dataset against a Space serving one canned /api/status."""
+    class _Resp:
+        def __init__(self, payload):
+            self.status = 200
+            self._payload = payload
+
+        async def json(self):
+            return self._payload
+
+        async def text(self):
+            return ""
+
+        async def read(self):
+            return b""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _Session:
+        def get(self, url, **kw):
+            return _Resp(status_payload)
+
+        def post(self, url, **kw):
+            return _Resp({"job_id": "job1"})
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    import aiohttp
+    orig_session, orig_sleep = aiohttp.ClientSession, asyncio.sleep
+    orig_daemon = main._daemon
+    main._daemon = object()  # process_dataset only needs the gate to pass
+    aiohttp.ClientSession = lambda *a, **kw: _Session()
+    asyncio.sleep = lambda *_a, **_kw: orig_sleep(0)
+    try:
+        return asyncio.run(main._handle_relay_command({
+            "id": "cmd1", "type": "process_dataset",
+            "args": {"space_url": "https://space.test", "source_repo": "u/raw",
+                     "target_repo": "u/ds"},
+        }))
+    finally:
+        aiohttp.ClientSession, asyncio.sleep = orig_session, orig_sleep
+        main._daemon = orig_daemon
+
+
+def test_done_without_a_dataset_is_an_error_not_a_success(monkeypatch):
+    # THE regression: "done" + result=None is what produced the 404 link. The
+    # device must not hand the fleet a success it can paper over.
+    monkeypatch.setattr(main, "_wake_space", _awake)
+    monkeypatch.setattr("huggingface_hub.get_token", lambda: "tok")
+
+    res = _process_result({"status": "done", "result": None, "quality": [
+        {"name": "20250101_120000/left", "errors": ["missing oakd_calib_offline.json"]},
+    ]})
+
+    assert res["status"] == "error"
+    assert "no episode made it through" in res["message"].lower()
+    # And it carries the reason, so the operator doesn't have to open the Space.
+    assert "missing oakd_calib_offline.json" in res["message"]
+
+
+def test_done_with_a_dataset_is_still_a_success(monkeypatch):
+    monkeypatch.setattr(main, "_wake_space", _awake)
+    monkeypatch.setattr("huggingface_hub.get_token", lambda: "tok")
+
+    res = _process_result({"status": "done", "result": "https://hf.co/datasets/u/ds"})
+
+    assert res == {"status": "ok", "result_url": "https://hf.co/datasets/u/ds"}
+
+
+def test_partial_success_reports_what_was_excluded(monkeypatch):
+    monkeypatch.setattr(main, "_wake_space", _awake)
+    monkeypatch.setattr("huggingface_hub.get_token", lambda: "tok")
+
+    res = _process_result({
+        "status": "done", "result": "https://hf.co/datasets/u/ds",
+        "quality": [{"name": "b", "errors": ["missing oakd_calib_offline.json"]}],
+    })
+
+    assert res["status"] == "ok"
+    assert "excluded" in res["message"]
+
+
+def test_space_error_is_enriched_with_the_reasons(monkeypatch):
+    monkeypatch.setattr(main, "_wake_space", _awake)
+    monkeypatch.setattr("huggingface_hub.get_token", lambda: "tok")
+
+    res = _process_result({
+        "status": "error", "error": "No recording has all the arms (left+right)",
+        "quality": [{"name": "a/left", "errors": ["missing oakd_calib_offline.json"]}],
+    })
+
+    assert res["status"] == "error"
+    assert "No recording has all the arms" in res["message"]
+    assert "missing oakd_calib_offline.json" in res["message"]
+
+
+async def _awake(*a, **kw):
+    return None  # the Space is up
+
+
+# --- 2. a bounded, retried episode upload ------------------------------------
+
+class _Hf:
+    """Records upload attempts; fails the first `fail_times` of them."""
+
+    def __init__(self, fail_times=0, hang=False):
+        self.calls = []
+        self._fail_times = fail_times
+        self._hang = hang
+
+    def upload_episode(self, ep_dir, repo, cb, dest, private):
+        self.calls.append(dest)
+        if self._hang:
+            import time
+            time.sleep(0.5)  # outlives the patched attempt timeout, not the suite
+        if len(self.calls) <= self._fail_times:
+            raise ConnectionResetError("connection reset by peer")
+        return f"https://hf.co/{repo}/{dest}"
+
+
+def _upload(hf, cancelled=lambda: False, ep_dir="/tmp/ep"):
+    return asyncio.run(main._upload_one_episode(
+        hf, ep_dir, "u/raw", "ep1/left", False, cancelled))
+
+
+def test_a_transient_failure_is_retried(monkeypatch):
+    # One bad minute on the link must not cost every other device's completed
+    # upload, which is what a single-attempt upload did.
+    monkeypatch.setattr(main, "_UPLOAD_RETRY_BASE_S", 0.0)
+    hf = _Hf(fail_times=2)
+
+    _upload(hf)
+
+    assert len(hf.calls) == 3
+
+
+def test_retries_are_bounded_and_report_the_last_error(monkeypatch):
+    monkeypatch.setattr(main, "_UPLOAD_RETRY_BASE_S", 0.0)
+    hf = _Hf(fail_times=99)
+
+    with pytest.raises(RuntimeError) as e:
+        _upload(hf)
+
+    assert len(hf.calls) == main._UPLOAD_MAX_ATTEMPTS
+    assert "connection reset" in str(e.value)
+
+
+def test_a_hung_attempt_times_out_instead_of_waiting_forever(monkeypatch):
+    # THE regression: an upload that never returns left the device pinned as
+    # "uploading" in the fleet forever. It must give up and report.
+    monkeypatch.setattr(main, "_UPLOAD_ATTEMPT_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(main, "_UPLOAD_RETRY_BASE_S", 0.0)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+
+    with pytest.raises(RuntimeError) as e:
+        _upload(_Hf(hang=True))
+
+    assert "TimeoutError" in str(e.value) or "timeout" in str(e.value).lower()
+
+
+def test_a_cancel_during_backoff_does_not_wait_it_out(monkeypatch):
+    # A cancel is the operator trying to free the device; making them sit out a
+    # retry delay is the opposite of what it is for.
+    monkeypatch.setattr(main, "_UPLOAD_RETRY_BASE_S", 30.0)
+    hf = _Hf(fail_times=99)
+
+    with pytest.raises(main._CommandCancelled):
+        _upload(hf, cancelled=lambda: len(hf.calls) >= 1)
+
+    assert len(hf.calls) == 1
+
+
+# --- 3. incomplete episodes are screened out BEFORE the upload ---------------
+
+class _Tm:
+    def __init__(self, root):
+        self.root = root
+
+    def episode_dir(self, eid):
+        return self.root / eid
+
+
+def _make_episode(root, eid, *, complete=True):
+    from grabette.episode_check import REQUIRED_FILES
+
+    ep = root / eid
+    ep.mkdir(parents=True)
+    for name in REQUIRED_FILES:
+        if not complete and name == "oakd_calib_offline.json":
+            continue
+        (ep / name).write_bytes(b"x")
+    (ep / "oakd_depth.mkv").write_bytes(b"x")
+    return ep
+
+
+def _run_upload(tmp_path, episode_ids, hf, monkeypatch):
+    monkeypatch.setattr("grabette.app.routers.tasks.get_task_manager",
+                        lambda: _Tm(tmp_path))
+    monkeypatch.setattr("grabette.app.routers.huggingface.get_hf_client", lambda: hf)
+    monkeypatch.setattr(main, "_daemon", object())
+    monkeypatch.setattr(main, "_UPLOAD_RETRY_BASE_S", 0.0)
+    return asyncio.run(main._handle_relay_command({
+        "id": "cmd1", "type": "upload_episodes",
+        "args": {"raw_repo": "u/raw", "role": "left", "episode_ids": episode_ids},
+    }))
+
+
+def test_an_episode_missing_its_calibration_is_never_uploaded(tmp_path, monkeypatch):
+    # Pushing it is pure waste: the Space rejects it, and in a bimanual build it
+    # drops the peer arm's good recording with it.
+    _make_episode(tmp_path, "ep_ok")
+    _make_episode(tmp_path, "ep_bad", complete=False)
+    hf = _Hf()
+
+    res = _run_upload(tmp_path, ["ep_ok", "ep_bad"], hf, monkeypatch)
+
+    assert res["status"] == "ok"
+    assert hf.calls == ["ep_ok/left"]
+    assert res["incomplete"] == [
+        {"episode_id": "ep_bad", "missing": ["oakd_calib_offline.json"]}]
+    # And it SAYS so — a build quietly assembled from a subset is the failure
+    # this accounting exists to prevent.
+    assert "oakd_calib_offline.json" in res["message"]
+
+
+def test_nothing_convertible_fails_immediately(tmp_path, monkeypatch):
+    # THE regression: uploading zero episodes and letting the build discover it
+    # has nothing to convert half an hour later, after every other device pushed.
+    _make_episode(tmp_path, "ep_bad", complete=False)
+    hf = _Hf()
+
+    res = _run_upload(tmp_path, ["ep_bad"], hf, monkeypatch)
+
+    assert res["status"] == "error"
+    assert hf.calls == []
+    assert "can be converted" in res["message"]
+    assert "oakd_calib_offline.json (1)" in res["message"]
+
+
+def test_a_complete_batch_uploads_untouched(tmp_path, monkeypatch):
+    _make_episode(tmp_path, "ep1")
+    _make_episode(tmp_path, "ep2")
+    hf = _Hf()
+
+    res = _run_upload(tmp_path, ["ep1", "ep2"], hf, monkeypatch)
+
+    assert res["status"] == "ok"
+    assert hf.calls == ["ep1/left", "ep2/left"]
+    assert res["incomplete"] == [] and "message" not in res
+
+
+def test_an_absent_episode_is_still_reported_as_missing(tmp_path, monkeypatch):
+    # Absent locally (deleted, never recorded here) stays distinct from present
+    # but unconvertible — they need different fixes.
+    _make_episode(tmp_path, "ep1")
+    hf = _Hf()
+
+    res = _run_upload(tmp_path, ["ep1", "gone"], hf, monkeypatch)
+
+    assert res["missing"] == ["gone"] and res["incomplete"] == []
+
+
+# --- 4. a stalled upload must never touch the capture path -------------------
+# The point of this section: on a Pi, a thread that keeps running while the
+# device records competes for CPU with the H.264 encoders and the OAK-D
+# drainers. asyncio.to_thread would put it in the DEFAULT executor — the very
+# pool the daemon's 50 Hz sensor poll and the OAK-D bring-up use. It must not.
+
+@pytest.fixture(autouse=True)
+def _reset_stall_counter():
+    main._stalled_uploads = 0
+    yield
+    main._stalled_uploads = 0
+
+
+def test_uploads_run_off_the_default_executor(monkeypatch):
+    seen = {}
+
+    class _Named:
+        def upload_episode(self, *a):
+            seen["thread"] = threading.current_thread().name
+
+    _upload(_Named())
+
+    assert seen["thread"].startswith("hf-upload"), seen["thread"]
+
+
+def test_a_stalled_upload_leaves_the_default_executor_free(monkeypatch):
+    # The regression this guards: an abandoned upload holding a default-executor
+    # worker starves the sensor poll and the OAK-D bring-up that share it.
+    monkeypatch.setattr(main, "_UPLOAD_ATTEMPT_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+    monkeypatch.setattr(main, "_UPLOAD_RETRY_BASE_S", 0.0)
+
+    async def _drive():
+        with pytest.raises(RuntimeError):
+            await main._upload_one_episode(_Hf(hang=True), "/tmp/ep", "u/raw",
+                                           "ep1/left", False, lambda: False)
+        # While that thread is still running, work handed to the DEFAULT
+        # executor must still be served immediately.
+        return await asyncio.wait_for(
+            asyncio.to_thread(lambda: threading.current_thread().name), timeout=1.0)
+
+    name = asyncio.run(_drive())
+
+    assert not name.startswith("hf-upload")
+    assert main._stalled_uploads == 1  # counted, not forgotten
+
+
+def test_a_stalled_thread_gives_its_slot_back_when_it_finishes(monkeypatch):
+    monkeypatch.setattr(main, "_UPLOAD_ATTEMPT_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+    hf = _Hf(hang=True)  # sleeps 0.5s, i.e. finishes well after we give up
+
+    with pytest.raises(RuntimeError):
+        _upload(hf)
+    assert main._stalled_uploads == 1
+
+    time.sleep(1.0)  # the abandoned thread completes
+
+    assert main._stalled_uploads == 0, "the done callback must release the slot"
+
+
+def test_a_saturated_uploader_refuses_instead_of_queueing_silently(monkeypatch):
+    # Queueing behind threads that cannot be interrupted looks exactly like the
+    # original bug from the operator's seat: an upload that never progresses.
+    monkeypatch.setattr(main, "_stalled_uploads", main._UPLOAD_WORKERS)
+    hf = _Hf()
+
+    with pytest.raises(RuntimeError) as e:
+        _upload(hf)
+
+    assert hf.calls == []
+    assert "reboot" in str(e.value)
+
+
+def test_repeated_stalls_leave_no_phantom_count(monkeypatch):
+    # The count gates future uploads, so a leak of even one is a device that
+    # slowly refuses to upload at all. Ordering the increment before the release
+    # callback is what prevents it — a thread finishing in between would
+    # otherwise decrement (clamped at 0) and let the increment linger forever.
+    monkeypatch.setattr(main, "_UPLOAD_ATTEMPT_TIMEOUT_S", 0.02)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            _upload(_Hf(hang=True))
+        time.sleep(0.7)  # let the abandoned thread finish and release its slot
+
+    assert main._stalled_uploads == 0

--- a/packages/grabette/tests/test_dataset_commands.py
+++ b/packages/grabette/tests/test_dataset_commands.py
@@ -39,6 +39,48 @@ def test_quality_summary_names_the_dominant_reason():
     assert "SLAM failed: no trajectory produced (1 episode(s))" in summary
 
 
+def test_excluded_episodes_are_split_back_into_recording_and_arm():
+    # The Space labels a role-layout episode "20250101_120000/left". The fleet
+    # keys everything by episode id, and "which arm" is what tells the operator
+    # which grabette to go and look at — so the label has to come apart.
+    out = main._space_excluded_episodes([
+        {"name": "20250101_120000/left", "excluded": True,
+         "errors": ["missing oakd_calib_offline.json"]},
+        {"name": "20250101_120100", "excluded": True, "verdict": "FAIL", "errors": []},
+        {"name": "20250101_120200/right", "excluded": False, "errors": ["a warning"]},
+    ])
+
+    assert out[0] == {"episode_id": "20250101_120000", "role": "left",
+                      "reason": "missing oakd_calib_offline.json"}
+    # No error text: still nameable, via the verdict.
+    assert out[1]["episode_id"] == "20250101_120100" and out[1]["role"] == ""
+    assert "FAIL" in out[1]["reason"]
+    # Kept episodes are not exclusions, however flagged they are.
+    assert len(out) == 2
+
+
+def test_excluded_episodes_tolerate_junk():
+    assert main._space_excluded_episodes(None) == []
+    assert main._space_excluded_episodes(["nope", {"excluded": True}]) == []
+
+
+def test_a_partial_conversion_forwards_the_episode_list(monkeypatch):
+    # The count the operator was missing is built from this list, so a successful
+    # build must carry it and not only the summary sentence.
+    monkeypatch.setattr(main, "_wake_space", _awake)
+    monkeypatch.setattr("huggingface_hub.get_token", lambda: "tok")
+
+    res = _process_result({
+        "status": "done", "result": "https://hf.co/datasets/u/ds",
+        "quality": [{"name": "ep1/left", "excluded": True,
+                     "errors": ["missing oakd_calib_offline.json"]}],
+    })
+
+    assert res["status"] == "ok"
+    assert res["excluded"] == [{"episode_id": "ep1", "role": "left",
+                               "reason": "missing oakd_calib_offline.json"}]
+
+
 def test_quality_summary_tolerates_junk():
     # The Space's payload is data from another service; a shape change must not
     # turn a reportable failure into an exception inside the error path.

--- a/packages/grabette/tests/test_dataset_commands.py
+++ b/packages/grabette/tests/test_dataset_commands.py
@@ -13,6 +13,11 @@ Both incidents these cover were reported from the field:
 
 So: a Space that pushed nothing must be an error, and an upload attempt must be
 bounded and retried rather than allowed to hang.
+
+The bound is on SILENCE, not on elapsed time, and the tests below are written to
+hold that line: abandoning an upload that was still making progress would be a
+second field incident, not a partial fix, so "slow is not stalled" gets a test of
+its own.
 """
 import asyncio
 import threading
@@ -222,6 +227,49 @@ class _Hf:
         return f"https://hf.co/{repo}/{dest}"
 
 
+class _Progressing:
+    """A slow upload that keeps reporting progress — the healthy case."""
+
+    def __init__(self, hf_module, total_s, tick_s=0.02):
+        self._hf = hf_module
+        self._total_s = total_s
+        self._tick_s = tick_s
+        self.calls = []
+
+    def upload_episode(self, ep_dir, repo, cb, dest, private):
+        self.calls.append(dest)
+        waited = 0.0
+        while waited < self._total_s:
+            time.sleep(self._tick_s)
+            waited += self._tick_s
+            self._hf.note_hub_activity()   # bytes are still moving
+        return f"https://hf.co/{repo}/{dest}"
+
+
+@pytest.fixture
+def heartbeat(monkeypatch):
+    """A working heartbeat source, driven by the stubs above.
+
+    Replaces the real marks rather than the real installer: the watchdog only
+    asks grabette.hf two things — is there a source, and how stale is it — so
+    stubbing those two is the whole surface, with no huggingface_hub in the loop.
+    """
+    from grabette import hf as hf_module
+
+    stamp = {"t": time.monotonic()}
+    monkeypatch.setattr(hf_module, "heartbeat_is_complete", lambda: True)
+    monkeypatch.setattr(hf_module, "note_hub_activity",
+                        lambda: stamp.__setitem__("t", time.monotonic()))
+    monkeypatch.setattr(hf_module, "hub_activity_age_s",
+                        lambda: time.monotonic() - stamp["t"])
+    return hf_module
+
+
+def _fast_watchdog(monkeypatch, stall_s=0.15):
+    monkeypatch.setattr(main, "_UPLOAD_STALL_TIMEOUT_S", stall_s)
+    monkeypatch.setattr(main, "_UPLOAD_WATCHDOG_POLL_S", 0.01)
+
+
 def _upload(hf, cancelled=lambda: False, ep_dir="/tmp/ep"):
     return asyncio.run(main._upload_one_episode(
         hf, ep_dir, "u/raw", "ep1/left", False, cancelled))
@@ -249,17 +297,107 @@ def test_retries_are_bounded_and_report_the_last_error(monkeypatch):
     assert "connection reset" in str(e.value)
 
 
-def test_a_hung_attempt_times_out_instead_of_waiting_forever(monkeypatch):
+def test_a_silent_attempt_is_abandoned_instead_of_waiting_forever(monkeypatch, heartbeat):
     # THE regression: an upload that never returns left the device pinned as
-    # "uploading" in the fleet forever. It must give up and report.
-    monkeypatch.setattr(main, "_UPLOAD_ATTEMPT_TIMEOUT_S", 0.05)
+    # "uploading" in the fleet forever. It must give up and report. _Hf(hang=True)
+    # sleeps without ever reporting progress, which is what "wedged" looks like.
+    _fast_watchdog(monkeypatch)
     monkeypatch.setattr(main, "_UPLOAD_RETRY_BASE_S", 0.0)
     monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
 
     with pytest.raises(RuntimeError) as e:
         _upload(_Hf(hang=True))
 
-    assert "TimeoutError" in str(e.value) or "timeout" in str(e.value).lower()
+    assert "no Hub activity" in str(e.value)
+
+
+def test_a_slow_but_progressing_upload_is_never_abandoned(monkeypatch, heartbeat):
+    # The requirement, and the reason the bound is not on elapsed time: this
+    # upload runs many times longer than the stall budget and must still finish.
+    # An elapsed-time cap of any value fails this test as soon as the link is
+    # slower than the throughput that value assumed.
+    _fast_watchdog(monkeypatch, stall_s=0.15)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+    hf = _Progressing(heartbeat, total_s=1.0)   # ~7x the stall budget
+
+    _upload(hf)   # must not raise
+
+    assert hf.calls == ["ep1/left"]
+
+
+def test_the_stall_clock_starts_at_the_submit(monkeypatch, heartbeat):
+    # xet hashes locally before it sends anything, so an upload's first mark can
+    # come well after the submit. Judged against a mark left over from some
+    # earlier, unrelated Hub call, such an upload would be abandoned before it
+    # ever got its chance — so the submit must reset the clock.
+    _fast_watchdog(monkeypatch, stall_s=0.3)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+
+    class _LateFirstByte:
+        def __init__(self):
+            self.calls = []
+
+        def upload_episode(self, ep_dir, repo, cb, dest, private):
+            self.calls.append(dest)
+            time.sleep(0.15)                 # hashing: nothing on the wire yet
+            heartbeat.note_hub_activity()    # first bytes
+            time.sleep(0.15)
+            return f"https://hf.co/{repo}/{dest}"
+
+    heartbeat.note_hub_activity()
+    time.sleep(0.4)   # staler than the whole stall budget, before we submit
+    hf = _LateFirstByte()
+
+    _upload(hf)   # must not raise
+
+    assert hf.calls == ["ep1/left"]
+
+
+def test_a_heartbeat_source_that_appears_late_is_picked_up(monkeypatch):
+    # The source is installed in the WORKER thread (HuggingFaceClient._get_api),
+    # so on the process's FIRST upload it does not exist yet when the wait starts.
+    # Reading it once up front would silently put that one upload on the blind
+    # bound — and installing it from the event loop instead would import the
+    # hf_xet extension there, stalling the daemon's poll.
+    from grabette import hf as hf_module
+
+    stamp = {"t": time.monotonic()}
+    asks = {"n": 0}
+
+    def complete():
+        asks["n"] += 1
+        return asks["n"] > 1
+
+    monkeypatch.setattr(hf_module, "heartbeat_is_complete", complete)
+    monkeypatch.setattr(hf_module, "note_hub_activity",
+                        lambda: stamp.__setitem__("t", time.monotonic()))
+    monkeypatch.setattr(hf_module, "hub_activity_age_s",
+                        lambda: time.monotonic() - stamp["t"])
+    _fast_watchdog(monkeypatch, stall_s=0.05)
+    # Large enough that the blind path could never produce this failure.
+    monkeypatch.setattr(main, "_UPLOAD_BLIND_ATTEMPT_TIMEOUT_S", 3600.0)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+
+    with pytest.raises(RuntimeError) as e:
+        _upload(_Hf(hang=True))
+
+    assert "no Hub activity" in str(e.value), "never left the blind bound"
+
+
+def test_without_a_heartbeat_source_the_watchdog_falls_back_to_elapsed_time(monkeypatch):
+    # No progress signal means silence proves nothing. Falling back to elapsed
+    # time reintroduces the false positive, which is why it is a fallback and
+    # not the mechanism — but no bound at all is the original bug.
+    from grabette import hf as hf_module
+    monkeypatch.setattr(hf_module, "heartbeat_is_complete", lambda: False)
+    monkeypatch.setattr(main, "_UPLOAD_BLIND_ATTEMPT_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(main, "_UPLOAD_WATCHDOG_POLL_S", 0.01)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+
+    with pytest.raises(RuntimeError) as e:
+        _upload(_Hf(hang=True))
+
+    assert "no progress signal available" in str(e.value)
 
 
 def test_a_cancel_during_backoff_does_not_wait_it_out(monkeypatch):
@@ -390,10 +528,10 @@ def test_uploads_run_off_the_default_executor(monkeypatch):
     assert seen["thread"].startswith("hf-upload"), seen["thread"]
 
 
-def test_a_stalled_upload_leaves_the_default_executor_free(monkeypatch):
+def test_a_stalled_upload_leaves_the_default_executor_free(monkeypatch, heartbeat):
     # The regression this guards: an abandoned upload holding a default-executor
     # worker starves the sensor poll and the OAK-D bring-up that share it.
-    monkeypatch.setattr(main, "_UPLOAD_ATTEMPT_TIMEOUT_S", 0.05)
+    _fast_watchdog(monkeypatch, stall_s=0.05)
     monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
     monkeypatch.setattr(main, "_UPLOAD_RETRY_BASE_S", 0.0)
 
@@ -412,8 +550,8 @@ def test_a_stalled_upload_leaves_the_default_executor_free(monkeypatch):
     assert main._stalled_uploads == 1  # counted, not forgotten
 
 
-def test_a_stalled_thread_gives_its_slot_back_when_it_finishes(monkeypatch):
-    monkeypatch.setattr(main, "_UPLOAD_ATTEMPT_TIMEOUT_S", 0.05)
+def test_a_stalled_thread_gives_its_slot_back_when_it_finishes(monkeypatch, heartbeat):
+    _fast_watchdog(monkeypatch, stall_s=0.05)
     monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
     hf = _Hf(hang=True)  # sleeps 0.5s, i.e. finishes well after we give up
 
@@ -426,7 +564,7 @@ def test_a_stalled_thread_gives_its_slot_back_when_it_finishes(monkeypatch):
     assert main._stalled_uploads == 0, "the done callback must release the slot"
 
 
-def test_a_saturated_uploader_refuses_instead_of_queueing_silently(monkeypatch):
+def test_a_saturated_uploader_refuses_instead_of_queueing_silently(monkeypatch, heartbeat):
     # Queueing behind threads that cannot be interrupted looks exactly like the
     # original bug from the operator's seat: an upload that never progresses.
     monkeypatch.setattr(main, "_stalled_uploads", main._UPLOAD_WORKERS)
@@ -439,12 +577,12 @@ def test_a_saturated_uploader_refuses_instead_of_queueing_silently(monkeypatch):
     assert "reboot" in str(e.value)
 
 
-def test_repeated_stalls_leave_no_phantom_count(monkeypatch):
+def test_repeated_stalls_leave_no_phantom_count(monkeypatch, heartbeat):
     # The count gates future uploads, so a leak of even one is a device that
     # slowly refuses to upload at all. Ordering the increment before the release
     # callback is what prevents it — a thread finishing in between would
     # otherwise decrement (clamped at 0) and let the increment linger forever.
-    monkeypatch.setattr(main, "_UPLOAD_ATTEMPT_TIMEOUT_S", 0.02)
+    _fast_watchdog(monkeypatch, stall_s=0.02)
     monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
 
     for _ in range(3):
@@ -453,3 +591,75 @@ def test_repeated_stalls_leave_no_phantom_count(monkeypatch):
         time.sleep(0.7)  # let the abandoned thread finish and release its slot
 
     assert main._stalled_uploads == 0
+
+
+# --- 5. the whole chain: real marking logic + real clock + real watchdog -------
+
+@pytest.fixture
+def real_heartbeat(monkeypatch):
+    """The real hf clock and the real xet updater; only completeness is forced.
+
+    The tests above stub the marks to drive the watchdog in isolation. These two
+    do the opposite: they exercise grabette.hf's actual progress logic through
+    app/main.py's actual watchdog, so a change that breaks the JOIN between them
+    — which each side's own tests would still pass — fails here.
+    """
+    from grabette import hf as hf_module
+
+    monkeypatch.setattr(hf_module, "heartbeat_is_complete", lambda: True)
+    monkeypatch.setattr(hf_module, "_last_activity", 0.0)
+    monkeypatch.setattr(main, "_UPLOAD_WORKERS", 99)  # never hit the stall guard
+    return hf_module
+
+
+class _XetTick:
+    """What hf_xet hands its progress callback."""
+
+    def __init__(self, processed=0, transferred=0):
+        self.total_bytes_completion_increment = processed
+        self.total_transfer_bytes_completion_increment = transferred
+
+
+def test_a_xet_transfer_that_ticks_without_moving_is_abandoned(monkeypatch,
+                                                               real_heartbeat):
+    # hf_xet ticks on a timer, so a wedged transfer keeps calling back. The whole
+    # point of tying the mark to an increment is that this still gets caught.
+    _fast_watchdog(monkeypatch, stall_s=0.15)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+    updater = real_heartbeat._marking_updater(None)
+
+    class _Wedged:
+        def upload_episode(self, ep_dir, repo, cb, dest, private):
+            for _ in range(40):          # 0.8s of ticking, nothing moving
+                time.sleep(0.02)
+                updater(_XetTick(), [])
+
+    with pytest.raises(RuntimeError) as e:
+        _upload(_Wedged())
+
+    assert "no Hub activity" in str(e.value)
+
+
+def test_a_xet_transfer_that_keeps_moving_is_not_abandoned(monkeypatch,
+                                                           real_heartbeat):
+    # The same shape, only the increments differ — and that alone must decide it.
+    _fast_watchdog(monkeypatch, stall_s=0.15)
+    monkeypatch.setattr(main, "_UPLOAD_MAX_ATTEMPTS", 1)
+    updater = real_heartbeat._marking_updater(None)
+
+    class _Moving:
+        def __init__(self):
+            self.calls = []
+
+        def upload_episode(self, ep_dir, repo, cb, dest, private):
+            self.calls.append(dest)
+            for _ in range(40):          # 0.8s, >5x the stall budget
+                time.sleep(0.02)
+                updater(_XetTick(transferred=65536), [])
+            return f"https://hf.co/{repo}/{dest}"
+
+    hf = _Moving()
+
+    _upload(hf)   # must not raise
+
+    assert hf.calls == ["ep1/left"]

--- a/packages/grabette/tests/test_dataset_commands.py
+++ b/packages/grabette/tests/test_dataset_commands.py
@@ -25,20 +25,6 @@ from grabette.app import main
 
 # --- 1. the Space said "done" but pushed nothing -----------------------------
 
-def test_quality_summary_names_the_dominant_reason():
-    quality = [
-        {"name": "a", "errors": ["missing oakd_calib_offline.json"]},
-        {"name": "b", "errors": ["missing oakd_calib_offline.json"]},
-        {"name": "c", "errors": ["SLAM failed: no trajectory produced"]},
-    ]
-
-    summary = main._space_quality_summary(quality)
-
-    # Counted, not listed, and the most frequent reason leads.
-    assert summary.startswith("missing oakd_calib_offline.json (2 episode(s))")
-    assert "SLAM failed: no trajectory produced (1 episode(s))" in summary
-
-
 def test_excluded_episodes_are_split_back_into_recording_and_arm():
     # The Space labels a role-layout episode "20250101_120000/left". The fleet
     # keys everything by episode id, and "which arm" is what tells the operator
@@ -79,14 +65,6 @@ def test_a_partial_conversion_forwards_the_episode_list(monkeypatch):
     assert res["status"] == "ok"
     assert res["excluded"] == [{"episode_id": "ep1", "role": "left",
                                "reason": "missing oakd_calib_offline.json"}]
-
-
-def test_quality_summary_tolerates_junk():
-    # The Space's payload is data from another service; a shape change must not
-    # turn a reportable failure into an exception inside the error path.
-    assert main._space_quality_summary(None) == ""
-    assert main._space_quality_summary([]) == ""
-    assert main._space_quality_summary(["nope", {"errors": []}]) == ""
 
 
 def _process_result(status_payload):
@@ -147,14 +125,33 @@ def test_done_without_a_dataset_is_an_error_not_a_success(monkeypatch):
     monkeypatch.setattr(main, "_wake_space", _awake)
     monkeypatch.setattr("huggingface_hub.get_token", lambda: "tok")
 
+    # Shape as the Space really emits it: a pre-check failure is recorded with
+    # excluded=True (see _run_pipeline_headless there).
     res = _process_result({"status": "done", "result": None, "quality": [
-        {"name": "20250101_120000/left", "errors": ["missing oakd_calib_offline.json"]},
+        {"name": "20250101_120000/left", "kind": "pre_check", "verdict": "ERROR",
+         "excluded": True, "errors": ["missing oakd_calib_offline.json"]},
     ]})
 
     assert res["status"] == "error"
     assert "no episode made it through" in res["message"].lower()
-    # And it carries the reason, so the operator doesn't have to open the Space.
-    assert "missing oakd_calib_offline.json" in res["message"]
+    # The reasons ride in `excluded`, per episode — the fleet reports them under
+    # the result line, so repeating them in the message only made the operator
+    # read the same causes twice.
+    assert res["excluded"] == [{"episode_id": "20250101_120000", "role": "left",
+                                "reason": "missing oakd_calib_offline.json"}]
+    assert "oakd_calib_offline.json" not in res["message"]
+
+
+def test_a_conversion_that_says_nothing_at_all_points_at_the_log(monkeypatch):
+    # The one case where the message has to carry the operator further: the Space
+    # gave us nothing structured, so there is no panel to send them to.
+    monkeypatch.setattr(main, "_wake_space", _awake)
+    monkeypatch.setattr("huggingface_hub.get_token", lambda: "tok")
+
+    res = _process_result({"status": "done", "result": None})
+
+    assert res["status"] == "error"
+    assert "see the Space log" in res["message"]
 
 
 def test_done_with_a_dataset_is_still_a_success(monkeypatch):
@@ -172,25 +169,33 @@ def test_partial_success_reports_what_was_excluded(monkeypatch):
 
     res = _process_result({
         "status": "done", "result": "https://hf.co/datasets/u/ds",
-        "quality": [{"name": "b", "errors": ["missing oakd_calib_offline.json"]}],
+        "quality": [{"name": "b", "excluded": True,
+                     "errors": ["missing oakd_calib_offline.json"]}],
     })
 
     assert res["status"] == "ok"
-    assert "excluded" in res["message"]
+    assert res["excluded"][0]["episode_id"] == "b"
+    # A successful build needs no message: the panel names the episodes.
+    assert "message" not in res
 
 
-def test_space_error_is_enriched_with_the_reasons(monkeypatch):
+def test_a_space_error_says_what_happened_and_lists_which(monkeypatch):
+    # Split on purpose: the message answers "what went wrong", the list answers
+    # "which of my takes are gone, and why". Putting both in the message was the
+    # redundancy — the operator read the causes once in the error line and again
+    # in the panel right below it.
     monkeypatch.setattr(main, "_wake_space", _awake)
     monkeypatch.setattr("huggingface_hub.get_token", lambda: "tok")
 
     res = _process_result({
         "status": "error", "error": "No recording has all the arms (left+right)",
-        "quality": [{"name": "a/left", "errors": ["missing oakd_calib_offline.json"]}],
+        "quality": [{"name": "a/left", "excluded": True,
+                     "errors": ["missing oakd_calib_offline.json"]}],
     })
 
     assert res["status"] == "error"
-    assert "No recording has all the arms" in res["message"]
-    assert "missing oakd_calib_offline.json" in res["message"]
+    assert res["message"] == "No recording has all the arms (left+right)"
+    assert res["excluded"][0]["reason"] == "missing oakd_calib_offline.json"
 
 
 async def _awake(*a, **kw):
@@ -315,11 +320,12 @@ def test_an_episode_missing_its_calibration_is_never_uploaded(tmp_path, monkeypa
 
     assert res["status"] == "ok"
     assert hf.calls == ["ep_ok/left"]
+    # A build quietly assembled from a subset is the failure this accounting
+    # exists to prevent — but the naming happens in `incomplete`, which the fleet
+    # renders per episode, not a second time in the message.
     assert res["incomplete"] == [
         {"episode_id": "ep_bad", "missing": ["oakd_calib_offline.json"]}]
-    # And it SAYS so — a build quietly assembled from a subset is the failure
-    # this accounting exists to prevent.
-    assert "oakd_calib_offline.json" in res["message"]
+    assert res["message"] == "uploaded 1 episode(s); skipped 1 that cannot be converted"
 
 
 def test_nothing_convertible_fails_immediately(tmp_path, monkeypatch):
@@ -332,8 +338,8 @@ def test_nothing_convertible_fails_immediately(tmp_path, monkeypatch):
 
     assert res["status"] == "error"
     assert hf.calls == []
-    assert "can be converted" in res["message"]
-    assert "oakd_calib_offline.json (1)" in res["message"]
+    assert res["message"] == "none of this device's 1 episode(s) can be converted"
+    assert res["incomplete"][0]["missing"] == ["oakd_calib_offline.json"]
 
 
 def test_a_complete_batch_uploads_untouched(tmp_path, monkeypatch):

--- a/packages/grabette/tests/test_dataset_commands.py
+++ b/packages/grabette/tests/test_dataset_commands.py
@@ -324,7 +324,7 @@ def test_an_episode_missing_its_calibration_is_never_uploaded(tmp_path, monkeypa
     # exists to prevent — but the naming happens in `incomplete`, which the fleet
     # renders per episode, not a second time in the message.
     assert res["incomplete"] == [
-        {"episode_id": "ep_bad", "missing": ["oakd_calib_offline.json"]}]
+        {"episode_id": "ep_bad", "role": "left", "missing": ["oakd_calib_offline.json"]}]
     assert res["message"] == "uploaded 1 episode(s); skipped 1 that cannot be converted"
 
 

--- a/packages/grabette/tests/test_episode_check.py
+++ b/packages/grabette/tests/test_episode_check.py
@@ -1,0 +1,72 @@
+"""Local completeness screen for a recorded episode (episode_check).
+
+The failure this guards against is specific and expensive: an episode that
+LOOKS recorded but lacks an artifact the conversion needs is uploaded in full,
+rejected on the Space, and — in a bimanual build — takes the peer arm's good
+recording down with it. The screen has to catch that before the upload, so the
+required set is pinned here against the pipeline's own contract.
+"""
+from grabette.episode_check import REQUIRED_FILES, missing_files
+
+
+def _write_episode(tmp_path, *, skip=(), depth="mkv"):
+    """A complete episode dir, minus whatever `skip` names."""
+    ep = tmp_path / "20250101_120000"
+    ep.mkdir()
+    for name in REQUIRED_FILES:
+        if name in skip:
+            continue
+        (ep / name).write_bytes(b"x")
+    if depth == "mkv" and "oakd_depth.mkv" not in skip:
+        (ep / "oakd_depth.mkv").write_bytes(b"x")
+    elif depth == "dir":
+        d = ep / "oakd_depth"
+        d.mkdir()
+        (d / "00000000.png").write_bytes(b"x")
+    return ep
+
+
+def test_complete_episode_has_nothing_missing(tmp_path):
+    assert missing_files(_write_episode(tmp_path)) == []
+
+
+def test_depth_png_sequence_satisfies_depth(tmp_path):
+    # stop_recording muxes the PNG dir into the .mkv, so an episode may carry
+    # either form depending on when it was recorded. Both are convertible.
+    assert missing_files(_write_episode(tmp_path, depth="dir")) == []
+
+
+def test_missing_calibration_is_reported_by_name(tmp_path):
+    # THE regression: this is the file whose silent absence sent a whole session
+    # to the Space only to be rejected there, episode by episode.
+    ep = _write_episode(tmp_path, skip=("oakd_calib_offline.json",))
+
+    assert missing_files(ep) == ["oakd_calib_offline.json"]
+
+
+def test_missing_depth_in_both_forms_is_reported(tmp_path):
+    ep = _write_episode(tmp_path, skip=("oakd_depth.mkv",), depth="none")
+
+    assert "oakd_depth.mkv" in missing_files(ep)
+
+
+def test_zero_byte_file_counts_as_missing(tmp_path):
+    # An interrupted recording leaves an empty video behind; upstream rejects it
+    # exactly like an absent one, so it must not pass the screen.
+    ep = _write_episode(tmp_path)
+    (ep / "oakd_left.mp4").write_bytes(b"")
+
+    assert missing_files(ep) == ["oakd_left.mp4"]
+
+
+def test_empty_depth_dir_counts_as_missing(tmp_path):
+    ep = _write_episode(tmp_path, skip=("oakd_depth.mkv",), depth="none")
+    (ep / "oakd_depth").mkdir()
+
+    assert "oakd_depth.mkv" in missing_files(ep)
+
+
+def test_several_missing_files_are_all_reported(tmp_path):
+    ep = _write_episode(tmp_path, skip=("oakd_imu.json", "angle_data.json"))
+
+    assert missing_files(ep) == ["angle_data.json", "oakd_imu.json"]

--- a/packages/grabette/tests/test_hardware_error.py
+++ b/packages/grabette/tests/test_hardware_error.py
@@ -236,17 +236,24 @@ class _FakeOakd:
         self.is_initialized = True
 
 
-def _backend(monkeypatch, *, fail):
+def _backend(monkeypatch, *, fail, angle_fail=False, enable_angle=True):
     from grabette.backend import rpi
+    from grabette.hardware import angle as angle_mod
     from grabette.hardware import oakd as oakd_mod
 
-    state = {"fail": fail}
+    state = {"fail": fail, "angle_fail": angle_fail}
 
     def _factory(sync):
         return _FakeOakd(sync, fail=state["fail"])
 
+    def _angle_factory(sync):
+        if state["angle_fail"]:
+            raise OSError("[Errno 121] Remote I/O error")
+        return types.SimpleNamespace(init_sensors=lambda: None)
+
     monkeypatch.setattr(oakd_mod, "OakdCapture", _factory)
-    b = rpi.RpiBackend()
+    monkeypatch.setattr(angle_mod, "AngleCapture", _angle_factory)
+    b = rpi.RpiBackend(enable_angle=enable_angle)
     return b, state
 
 
@@ -306,3 +313,99 @@ def test_a_plain_missing_oakd_is_not_a_fault(monkeypatch):
 def asyncio_run(coro):
     import asyncio
     return asyncio.run(coro)
+
+
+# --- the angle sensors: the same defect, a different sensor -------------------
+# stop_capture only writes angle_data.json when there are samples, and that file
+# is a REQUIRED conversion input. So "angle sensors not available, continuing
+# without them" was the OAK-D calibration incident again: a grabette filling its
+# card with episodes the Space rejects one by one.
+
+def test_angle_init_failure_latches_a_fault(monkeypatch):
+    b, _ = _backend(monkeypatch, fail=False, angle_fail=True)
+
+    b._init_angle_sensors()
+
+    assert "angle_data.json" in b.hardware_error
+    assert "I2C" in b.hardware_error  # names where to look
+    assert b._angle is None
+
+
+def test_capture_is_refused_without_angle_sensors(monkeypatch, tmp_path):
+    b, _ = _backend(monkeypatch, fail=False, angle_fail=True)
+    b._init_angle_sensors()
+
+    with pytest.raises(RuntimeError, match="angle"):
+        asyncio_run(b.start_capture(tmp_path / "ep"))
+
+    assert not b.is_capturing
+
+
+def test_a_deliberately_angle_less_setup_is_not_a_fault(monkeypatch):
+    # enable_angle=False is a choice (bench rig), not a broken sensor.
+    b, _ = _backend(monkeypatch, fail=False, angle_fail=True, enable_angle=False)
+
+    b._note_angle_output(None)
+
+    assert b.hardware_error == ""
+
+
+def test_zero_samples_over_a_whole_recording_latches_the_fault(monkeypatch):
+    # The second door: the sensors initialised fine and then produced nothing,
+    # so no angle_data.json is written — unconvertible, and silent.
+    b, _ = _backend(monkeypatch, fail=False)
+
+    b._note_angle_output(None)
+
+    assert "no samples" in b.hardware_error
+
+
+def test_samples_coming_back_clear_the_fault(monkeypatch):
+    # Samples are the only proof the sensors actually work — an init alone
+    # cannot give it.
+    b, _ = _backend(monkeypatch, fail=False)
+    b._note_angle_output(None)
+
+    b._note_angle_output([{"cts": 0, "value": [0.1, 0.2]}])
+
+    assert b.hardware_error == ""
+
+
+def test_the_angle_fault_clears_when_the_sensors_come_back(monkeypatch, tmp_path):
+    # Self-healing through the start path: the bring-up IS the retry.
+    b, state = _backend(monkeypatch, fail=False, angle_fail=True)
+    b._init_angle_sensors()
+    assert b.hardware_error
+
+    state["angle_fail"] = False
+    b._init_angle_sensors()
+
+    assert b.hardware_error == ""
+
+
+def test_the_two_faults_are_independent(monkeypatch):
+    # THE regression a single _hw_error string would cause: a successful OAK-D
+    # bring-up quietly wiping a live angle fault, and the device recording again
+    # with no gripper channel.
+    b, state = _backend(monkeypatch, fail=True, angle_fail=True)
+    b._init_oakd()
+    b._init_angle_sensors()
+    assert "calibration" in b.hardware_error and "angle" in b.hardware_error
+
+    state["fail"] = False
+    b._init_oakd()  # OAK-D fixed — the angle sensors are still dead
+
+    assert "calibration" not in b.hardware_error
+    assert "angle_data.json" in b.hardware_error
+
+
+def test_both_faults_are_reported_in_a_stable_order(monkeypatch):
+    # Fixing one and still being refused, with no clue about the other, is a
+    # maddening way to spend an afternoon.
+    b, _ = _backend(monkeypatch, fail=True, angle_fail=True)
+    b._init_angle_sensors()
+    b._init_oakd()
+
+    first, second = b.hardware_error, b.hardware_error
+    assert first == second
+    assert first.index("calibration") < first.index("angle_data.json")

--- a/packages/grabette/tests/test_hardware_error.py
+++ b/packages/grabette/tests/test_hardware_error.py
@@ -1,0 +1,308 @@
+"""A grabette that cannot record convertible episodes must say so, loudly.
+
+The failure being closed here is silent by construction: the OAK-D answers, the
+pipeline runs, the dashboard looks healthy — but oakd_calib_offline.json is
+never written, so every episode of the session is rejected days later by the
+SLAM Space. Nothing on the device said a word.
+
+Three things now have to hold:
+  * an unreadable/degenerate calibration is an error, not a warning;
+  * an episode is never written without it;
+  * the fault is visible on the device itself — the LED pattern, since a
+    grabette in the field has no screen.
+"""
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+# hardware.button talks to gpiod at import time, and the test host has no GPIO.
+# Stub it so the LED PATTERN (pure timing logic over a line handle) stays
+# testable off-hardware — it is the operator's only feedback channel, so it is
+# exactly the part that must not be left unpinned.
+if "gpiod" not in sys.modules:  # pragma: no cover - import shim
+    _line = types.SimpleNamespace(
+        Bias=types.SimpleNamespace(PULL_UP="pull_up"),
+        Direction=types.SimpleNamespace(OUTPUT="out", INPUT="in"),
+        Value=types.SimpleNamespace(ACTIVE="active", INACTIVE="inactive"),
+    )
+    gpiod = types.ModuleType("gpiod")
+    gpiod.line = _line
+    gpiod.LineSettings = lambda **kw: kw
+    gpiod.request_lines = lambda *a, **kw: None
+    sys.modules["gpiod"] = gpiod
+    sys.modules["gpiod.line"] = _line
+
+from grabette.hardware.button import LedButton  # noqa: E402
+from grabette.hardware.oakd import OakdCalibrationError, OakdCapture  # noqa: E402
+
+
+# --- the calibration itself ---------------------------------------------------
+
+class _Calib:
+    def __init__(self, fx=600.0, fy=600.0, baseline_cm=7.5, raises=False):
+        self._fx, self._fy, self._baseline_cm, self._raises = fx, fy, baseline_cm, raises
+
+    def getCameraIntrinsics(self, socket, w, h):  # noqa: N802 - depthai API
+        if self._raises:
+            raise RuntimeError("EEPROM read failed")
+        return [[self._fx, 0.0, w / 2], [0.0, self._fy, h / 2], [0.0, 0.0, 1.0]]
+
+    def getImuToCameraExtrinsics(self, socket, useSpecTranslation):  # noqa: N802,N803
+        return [[1.0, 0, 0, 0], [0, 1.0, 0, 0], [0, 0, 1.0, 0], [0, 0, 0, 1.0]]
+
+    def getBaselineDistance(self, a, b):  # noqa: N802 - depthai API
+        return self._baseline_cm
+
+
+class _Device:
+    def __init__(self, calib):
+        self._calib = calib
+
+    def readCalibration(self):  # noqa: N802 - depthai API
+        return self._calib
+
+
+@pytest.fixture(autouse=True)
+def _stub_depthai(monkeypatch):
+    dai = types.ModuleType("depthai")
+    dai.CameraBoardSocket = types.SimpleNamespace(CAM_B="CAM_B", CAM_C="CAM_C")
+    monkeypatch.setitem(sys.modules, "depthai", dai)
+
+
+def test_a_good_calibration_comes_back_flat():
+    calib = OakdCapture._dump_calib_offline(_Device(_Calib()), (640, 400))
+
+    assert calib["fx"] == 600.0
+    assert calib["baseline"] == pytest.approx(0.075)
+    assert {"width", "height", "fx", "fy", "cx", "cy", "baseline", "imu_to_cam"} <= calib.keys()
+
+
+def test_an_unreadable_calibration_raises_instead_of_returning_empty():
+    # It used to log a warning and return {} — start_recording then simply
+    # skipped the file, which is the whole incident.
+    with pytest.raises(OakdCalibrationError) as e:
+        OakdCapture._dump_calib_offline(_Device(_Calib(raises=True)), (640, 400))
+
+    assert "EEPROM read failed" in str(e.value)
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"fx": 0.0},           # degenerate focal length
+    {"baseline_cm": 0.0},  # no stereo baseline
+])
+def test_a_degenerate_calibration_is_refused(kwargs):
+    # Present-but-unusable fails the same upstream check as absent, so it has to
+    # fail here too — otherwise the file is written and the rejection just moves
+    # back to the Space.
+    with pytest.raises(OakdCalibrationError):
+        OakdCapture._dump_calib_offline(_Device(_Calib(**kwargs)), (640, 400))
+
+
+def test_start_recording_refuses_without_a_calibration(tmp_path):
+    # Belt and braces behind the init-time gate: even if something bypassed it,
+    # no episode dir is created and nothing is recorded.
+    cap = object.__new__(OakdCapture)
+    cap._initialized = True
+    cap._recording = False
+    cap.sync = types.SimpleNamespace(is_started=True)
+    cap._calib_offline = None
+    ep = tmp_path / "20250101_120000"
+
+    with pytest.raises(OakdCalibrationError):
+        OakdCapture.start_recording(cap, ep)
+
+    assert not ep.exists()
+
+
+# --- the error LED ------------------------------------------------------------
+
+class _FakeLine:
+    """Records every (t, value) written to the LED line."""
+
+    def __init__(self):
+        self.writes = []
+        self._t0 = time.monotonic()
+
+    def set_value(self, pin, value):
+        self.writes.append((time.monotonic() - self._t0, value))
+
+
+def _led():
+    btn = object.__new__(LedButton)
+    btn._led_pin = 11
+    btn._led_request = _FakeLine()
+    btn._blink_thread = None
+    btn._blink_stop = threading.Event()
+    return btn
+
+
+def test_error_pattern_is_a_burst_of_three_then_a_gap():
+    btn = _led()
+    btn.led_pulses(count=3, on=0.01, off=0.01, gap=1.0)
+    time.sleep(0.3)  # well inside the gap: one burst has fired, the next has not
+    btn.led_off()
+
+    writes = btn._led_request.writes
+    ons = [t for t, v in writes if v == "active"]
+    assert len(ons) == 3, f"expected one burst of 3 pulses, got {len(ons)}"
+    # The dark gap is what makes the pattern read as a fault rather than as yet
+    # another blink: the whole burst must be brief next to the pause following it.
+    burst_span = ons[-1] - ons[0]
+    assert burst_span < 0.25, f"burst took {burst_span:.3f}s — it should be a blip"
+    assert writes[-1][1] == "inactive", "the LED must end the burst dark"
+
+
+def test_error_pattern_repeats():
+    btn = _led()
+    btn.led_pulses(count=3, on=0.01, off=0.01, gap=0.05)
+    time.sleep(0.35)
+    btn.led_off()
+
+    ons = [t for t, v in btn._led_request.writes if v == "active"]
+    assert len(ons) >= 6, "the burst must repeat, not fire once"
+
+
+def test_switching_pattern_stops_the_previous_one():
+    # Two pattern threads on one line produce a pattern that is neither. A
+    # switch must leave exactly one writer.
+    btn = _led()
+    btn.led_pulses(count=3, on=0.01, off=0.01, gap=0.05)
+    time.sleep(0.05)
+    btn.led_blink(0.01)
+    time.sleep(0.05)
+    live = [t for t in threading.enumerate() if t is btn._blink_thread]
+    btn.led_off()
+
+    assert len(live) == 1
+    assert threading.active_count() < 10  # no thread pile-up
+
+
+# --- the LED state machine ----------------------------------------------------
+
+class _Backend:
+    is_teleop_active = False
+    is_teleop_sending = False
+    is_stopping = False
+    is_starting = False
+    is_capturing = False
+    hardware_error = ""
+
+
+def _desired(**state):
+    from grabette.button_listener import ButtonListener
+
+    b = _Backend()
+    for k, v in state.items():
+        setattr(b, k, v)
+    listener = ButtonListener(b, None)
+    return listener._desired_led()
+
+
+def test_hardware_error_drives_the_error_state():
+    assert _desired(hardware_error="no OAK-D calibration") == "error"
+
+
+def test_hardware_error_outranks_every_busy_state():
+    # A fault the busy patterns can hide is a fault nobody sees.
+    assert _desired(hardware_error="boom", is_capturing=True) == "error"
+    assert _desired(hardware_error="boom", is_starting=True) == "error"
+    assert _desired(hardware_error="boom", is_teleop_active=True) == "error"
+
+
+def test_no_error_leaves_the_normal_states_alone():
+    assert _desired() == "off"
+    assert _desired(is_capturing=True) == "on"
+    assert _desired(is_stopping=True) == "blink_fast"
+
+
+# --- the backend gate: refuse to record, but stay recoverable -----------------
+
+class _FakeOakd:
+    """Stands in for OakdCapture: init_device either works or fails the way a
+    calibration read does."""
+
+    instances = []
+
+    def __init__(self, sync, fail=False):
+        self.fail = fail
+        self.is_initialized = False
+
+    def init_device(self):
+        if self.fail:
+            raise OakdCalibrationError("could not read the OAK-D calibration: EEPROM read failed")
+        self.is_initialized = True
+
+
+def _backend(monkeypatch, *, fail):
+    from grabette.backend import rpi
+    from grabette.hardware import oakd as oakd_mod
+
+    state = {"fail": fail}
+
+    def _factory(sync):
+        return _FakeOakd(sync, fail=state["fail"])
+
+    monkeypatch.setattr(oakd_mod, "OakdCapture", _factory)
+    b = rpi.RpiBackend()
+    return b, state
+
+
+def test_a_calibration_failure_latches_a_hardware_error(monkeypatch):
+    b, _ = _backend(monkeypatch, fail=True)
+
+    b._init_oakd()
+
+    assert "calibration" in b.hardware_error
+    # And it names what to do about it — a fault the operator can't act on is
+    # only marginally better than a silent one.
+    assert "Power-cycle" in b.hardware_error
+
+
+def test_capture_is_refused_while_the_fault_stands(monkeypatch, tmp_path):
+    b, _ = _backend(monkeypatch, fail=True)
+
+    with pytest.raises(RuntimeError) as e:
+        asyncio_run(b.start_capture(tmp_path / "ep"))
+
+    assert "calibration" in str(e.value)
+    assert not b.is_capturing
+    assert not (tmp_path / "ep").exists()  # nothing was recorded
+
+
+def test_the_fault_clears_once_the_calibration_reads(monkeypatch, tmp_path):
+    # The gate runs AFTER the OAK-D bring-up, so pressing again retries the
+    # calibration read. Without that, a fault latched at boot would make a reboot
+    # the only way out — the same dead end this whole change is about.
+    b, state = _backend(monkeypatch, fail=True)
+    with pytest.raises(RuntimeError):
+        asyncio_run(b.start_capture(tmp_path / "ep1"))
+
+    state["fail"] = False  # cable reseated
+    b._init_oakd()
+
+    assert b.hardware_error == ""
+
+
+def test_a_plain_missing_oakd_is_not_a_fault(monkeypatch):
+    # A bench setup with no OAK-D attached keeps working as before: only an
+    # unusable CALIBRATION is treated as a fault.
+    from grabette.hardware import oakd as oakd_mod
+
+    def _boom(sync):
+        raise RuntimeError("no device found")
+
+    monkeypatch.setattr(oakd_mod, "OakdCapture", _boom)
+    from grabette.backend import rpi
+    b = rpi.RpiBackend()
+
+    b._init_oakd()
+
+    assert b.hardware_error == ""
+
+
+def asyncio_run(coro):
+    import asyncio
+    return asyncio.run(coro)

--- a/packages/grabette/tests/test_task.py
+++ b/packages/grabette/tests/test_task.py
@@ -63,6 +63,54 @@ def test_imu_sample_count_from_metadata(tmp_path):
 # back to Unassigned), while delete_task_by_name() is the fleet's destructive
 # path (the recordings go too). See #98.
 
+# ── an unreadable episode must not blank the dashboard ────────────────────────
+
+def test_a_truncated_metadata_does_not_break_the_episode(tmp_path):
+    # A power cut (or a full SD card) between open() and flush leaves a 0-byte
+    # metadata.json. Raising here 500'd GET /api/tasks.
+    ep = _make_episode(tmp_path, "ep_bad", ["raw_video.mp4"])
+    (ep / "metadata.json").write_text("")
+
+    info = TaskManager(data_dir=tmp_path)._get_episode_info("ep_bad")
+
+    assert info.metadata_ok is False, "a zeroed metadata must be reported as such"
+    assert info.has_video is True, "the episode's files are still on disk"
+    assert info.duration_seconds == 0.0
+
+
+def test_one_unreadable_episode_does_not_hide_every_other_task(tmp_path):
+    # THE regression: one bad episode used to take the whole listing down, so
+    # the dashboard showed no tasks at all — while the fleet, which reports from
+    # the registry and never reads these files, still showed them.
+    _make_episode(tmp_path, "ep_ok", ["raw_video.mp4"], {"duration_seconds": 4.0})
+    bad = _make_episode(tmp_path, "ep_bad", ["raw_video.mp4"])
+    (bad / "metadata.json").write_text("")
+    tm = TaskManager(data_dir=tmp_path)
+    good = tm.create_task("good")
+    broken = tm.create_task("broken")
+    tm._find_task(good)["episode_ids"].append("ep_ok")
+    tm._find_task(broken)["episode_ids"].append("ep_bad")
+
+    tasks = tm.list_tasks()   # must not raise
+
+    by_name = {t.name: t for t in tasks}
+    assert by_name["good"].episodes[0].duration_seconds == 4.0
+    assert by_name["broken"].episodes[0].metadata_ok is False
+    assert {"Unassigned", "good", "broken"} <= set(by_name)
+
+
+def test_a_missing_metadata_is_reported_as_not_ok(tmp_path):
+    # metadata.json is written LAST so its presence means "fully saved". Absent
+    # therefore means the episode never finished — not that it has no counters.
+    ep = tmp_path / "episodes" / "ep_partial"
+    ep.mkdir(parents=True)
+    (ep / "raw_video.mp4").write_text("x")
+
+    info = TaskManager(data_dir=tmp_path)._get_episode_info("ep_partial")
+
+    assert info.metadata_ok is False
+
+
 def test_delete_task_keeps_episodes(tmp_path):
     # #98: delete_task() preserves the episodes, reassigning them to Unassigned.
     _make_episode(tmp_path, "ep_a", ["oakd_imu.json"])

--- a/packages/grabette/tests/test_upload_heartbeat.py
+++ b/packages/grabette/tests/test_upload_heartbeat.py
@@ -1,0 +1,263 @@
+"""The progress signal the upload watchdog is built on.
+
+app/main.py abandons an upload only when this heartbeat goes stale, so a
+heartbeat that is silently NOT wired turns the watchdog blind — and a blind
+watchdog falls back to an elapsed-time bound, i.e. to the false positive the
+whole design exists to avoid. Hence tests on the wiring itself, not just on the
+watchdog that reads it.
+
+The xet source is the one that matters. hf-xet is a hard dependency of
+huggingface_hub on every machine we run on and xet is the default upload path,
+yet it moves its bytes in a Rust stack, outside the httpx client whose socket
+timeouts are the rest of this defence. Nothing else can see that transfer.
+"""
+import time
+
+import pytest
+
+from grabette import hf
+
+
+@pytest.fixture(autouse=True)
+def _fresh_heartbeat(monkeypatch):
+    """Reset the module's install-once state; it is process-wide by design."""
+    monkeypatch.setattr(hf, "_heartbeat_installed", False)
+    monkeypatch.setattr(hf, "_heartbeat_sources", set())
+    monkeypatch.setattr(hf, "_last_activity", 0.0)
+
+
+# --- the clock ----------------------------------------------------------------
+
+def test_an_unmarked_heartbeat_reports_no_age_rather_than_zero():
+    # Zero would read as "activity right now", which is the opposite of the
+    # truth and would make a wedged upload look healthy forever.
+    assert hf.hub_activity_age_s() is None
+
+
+def test_marking_makes_the_age_readable_and_small():
+    hf.note_hub_activity()
+
+    age = hf.hub_activity_age_s()
+
+    assert age is not None and age < 1.0
+
+
+def test_the_age_grows_with_silence():
+    hf.note_hub_activity()
+    first = hf.hub_activity_age_s()
+    time.sleep(0.05)
+
+    assert hf.hub_activity_age_s() > first
+
+
+# --- completeness: a PARTIAL heartbeat must not be trusted --------------------
+
+def test_one_source_is_not_enough():
+    # The trap this guards: with only httpx wired, a xet transfer emits no marks
+    # for its entire duration, so trusting staleness would abandon a healthy
+    # upload — the one outcome the watchdog must never produce.
+    hf._add_source("httpx")
+
+    assert hf.heartbeat_sources() == {"httpx"}
+    assert not hf.heartbeat_is_complete()
+
+
+def test_the_other_single_source_is_not_enough_either():
+    hf._add_source("xet")
+
+    assert not hf.heartbeat_is_complete()
+
+
+def test_both_sources_make_the_heartbeat_trustworthy():
+    hf._add_source("httpx")
+    hf._add_source("xet")
+
+    assert hf.heartbeat_is_complete()
+
+
+# --- the xet hook -------------------------------------------------------------
+
+@pytest.fixture
+def fake_xet(monkeypatch):
+    """Stand-in hf_xet whose upload functions match the real signature.
+
+    The real signature is asserted separately below, so this stays a fake without
+    becoming a fiction: if hf_xet ever reorders its parameters, that other test
+    fails rather than this one silently testing the wrong shape.
+    """
+    hf_xet = pytest.importorskip("hf_xet")
+    calls = []
+
+    def upload_files(file_paths, endpoint, token_info, token_refresher,
+                     progress_updater, _repo_type, request_headers=None,
+                     sha256s=None, skip_sha256=False):
+        calls.append(progress_updater)
+        return "committed"
+
+    monkeypatch.setattr(hf_xet, "upload_files", upload_files)
+    monkeypatch.setattr(hf_xet, "upload_bytes", upload_files)
+    return hf_xet, calls
+
+
+def test_the_real_hf_xet_signature_still_has_the_progress_argument():
+    # The hook injects by POSITION, so this is the assumption that would let it
+    # pass a callable where the Rust side expects a repo type. Asserted here, and
+    # re-checked at install time, so a reordering degrades instead of corrupting.
+    hf_xet = pytest.importorskip("hf_xet")
+
+    index = hf._xet_progress_index(hf_xet.upload_files)
+
+    assert index == 4, f"hf_xet.upload_files moved its progress argument to {index}"
+
+
+def test_the_injected_updater_marks_the_heartbeat(fake_xet):
+    hf_xet, calls = fake_xet
+
+    hf.install_upload_heartbeat()
+    hf_xet.upload_files(["f"], "ep", ("t", 1), None, None, "dataset")
+    calls[0]("total", [])   # the Rust side reporting progress
+
+    assert "xet" in hf.heartbeat_sources()
+    assert hf.hub_activity_age_s() is not None, "the injected updater never marked"
+
+
+def test_it_marks_even_when_progress_bars_are_off(fake_xet):
+    # With bars disabled huggingface_hub builds no reporter and passes None. That
+    # is the realistic way to lose this heartbeat — someone quieting tqdm in the
+    # systemd unit — so chaining onto None is the case that matters most.
+    hf_xet, calls = fake_xet
+
+    hf.install_upload_heartbeat()
+    hf_xet.upload_files(["f"], "ep", ("t", 1), None, None, "dataset")
+    calls[0]("total", [])
+
+    assert hf.hub_activity_age_s() is not None
+
+
+def test_an_existing_reporter_still_receives_its_updates(fake_xet):
+    # Marking must not cost the operator their progress bars.
+    hf_xet, calls = fake_xet
+    seen = []
+
+    hf.install_upload_heartbeat()
+    hf_xet.upload_files(["f"], "ep", ("t", 1), None,
+                        lambda *a: seen.append(a), "dataset")
+    calls[0]("total", ["items"])
+
+    assert seen == [("total", ["items"])]
+
+
+def test_the_progress_argument_is_hooked_when_passed_by_keyword(fake_xet):
+    hf_xet, calls = fake_xet
+
+    hf.install_upload_heartbeat()
+    hf_xet.upload_files(["f"], "ep", ("t", 1), None, _repo_type="dataset",
+                        progress_updater=None)
+    calls[0]("total", [])
+
+    assert hf.hub_activity_age_s() is not None
+
+
+def test_installing_twice_does_not_stack_wrappers(fake_xet):
+    hf_xet, _ = fake_xet
+
+    hf.install_upload_heartbeat()
+    wrapped_once = hf_xet.upload_files
+    hf._heartbeat_installed = False   # force a second real attempt
+    hf.install_upload_heartbeat()
+
+    assert hf_xet.upload_files is wrapped_once
+
+
+def test_a_renamed_progress_argument_is_reported_not_injected(monkeypatch):
+    # A future hf_xet could reorder or rename it. Injecting blindly would hand a
+    # callable to the wrong parameter; refusing to install just costs the source.
+    hf_xet = pytest.importorskip("hf_xet")
+    monkeypatch.setattr(hf_xet, "upload_files",
+                        lambda paths, endpoint, renamed_cb: None)
+    monkeypatch.setattr(hf_xet, "upload_bytes",
+                        lambda paths, endpoint, renamed_cb: None)
+
+    hf.install_upload_heartbeat()
+
+    assert "xet" not in hf.heartbeat_sources()
+    assert not hf.heartbeat_is_complete()
+
+
+def test_a_missing_upload_function_is_reported_not_raised(monkeypatch):
+    hf_xet = pytest.importorskip("hf_xet")
+    monkeypatch.delattr(hf_xet, "upload_files")
+    monkeypatch.delattr(hf_xet, "upload_bytes")
+
+    hf.install_upload_heartbeat()   # must not raise
+
+    assert "xet" not in hf.heartbeat_sources()
+
+
+# --- the mark must mean "bytes moved", not "the library spoke" ----------------
+
+class _Tick:
+    """A stand-in for hf_xet's PyTotalProgressUpdate."""
+
+    def __init__(self, processed=0, transferred=0):
+        self.total_bytes_completion_increment = processed
+        self.total_transfer_bytes_completion_increment = transferred
+
+
+def test_a_tick_reporting_no_movement_does_not_mark(fake_xet):
+    # hf_xet ticks on a timer (it reports a completion RATE), so a wedged
+    # transfer keeps calling back. Marking on arrival would call it alive
+    # forever — the original hang, one layer up.
+    hf_xet, calls = fake_xet
+
+    hf.install_upload_heartbeat()
+    hf_xet.upload_files(["f"], "ep", ("t", 1), None, None, "dataset")
+    for _ in range(5):
+        calls[0](_Tick(), [])
+
+    assert hf.hub_activity_age_s() is None, "a wedged transfer looked alive"
+
+
+def test_a_transfer_increment_marks(fake_xet):
+    hf_xet, calls = fake_xet
+
+    hf.install_upload_heartbeat()
+    hf_xet.upload_files(["f"], "ep", ("t", 1), None, None, "dataset")
+    calls[0](_Tick(transferred=4096), [])
+
+    assert hf.hub_activity_age_s() is not None
+
+
+def test_a_hashing_increment_marks_too(fake_xet):
+    # The local hashing phase advances total_bytes, not transfer_bytes. Missing
+    # it would abandon every upload whose hashing outlasts the stall budget.
+    hf_xet, calls = fake_xet
+
+    hf.install_upload_heartbeat()
+    hf_xet.upload_files(["f"], "ep", ("t", 1), None, None, "dataset")
+    calls[0](_Tick(processed=1 << 20), [])
+
+    assert hf.hub_activity_age_s() is not None
+
+
+def test_an_unrecognised_payload_marks_rather_than_going_silent(fake_xet):
+    # Direction of the fallback: not spotting a hang costs a device held until
+    # the blind bound; withholding a mark kills a healthy upload.
+    hf_xet, calls = fake_xet
+
+    hf.install_upload_heartbeat()
+    hf_xet.upload_files(["f"], "ep", ("t", 1), None, None, "dataset")
+    calls[0](object(), [])
+
+    assert hf.hub_activity_age_s() is not None
+
+
+def test_the_real_increment_fields_still_exist():
+    # _progress_moved falls back to marking unconditionally when it recognises
+    # nothing, so a rename here would silently disable hang detection.
+    hf_xet = pytest.importorskip("hf_xet")
+
+    missing = [n for n in hf._XET_INCREMENTS
+               if not hasattr(hf_xet.PyTotalProgressUpdate, n)]
+
+    assert not missing, f"hf_xet renamed {missing}"

--- a/packages/grabette/tests/test_upload_heartbeat.py
+++ b/packages/grabette/tests/test_upload_heartbeat.py
@@ -11,6 +11,7 @@ huggingface_hub on every machine we run on and xet is the default upload path,
 yet it moves its bytes in a Rust stack, outside the httpx client whose socket
 timeouts are the rest of this defence. Nothing else can see that transfer.
 """
+import inspect
 import time
 
 import pytest
@@ -77,6 +78,29 @@ def test_both_sources_make_the_heartbeat_trustworthy():
 
 # --- the xet hook -------------------------------------------------------------
 
+def _reject_like_hf_xet(updater) -> None:
+    """Raise what the Rust side raises for a progress callback it will not take.
+
+    hf_xet introspects the callback and accepts one parameter of any name, or
+    exactly two named (total_update, item_updates). Without this the fake accepts
+    callables the real library refuses, and the heartbeat wrapper can ship a
+    signature that fails every upload before a byte moves — which is what
+    happened. Kept next to the fake so every test below exercises the contract.
+    """
+    if updater is None:
+        return
+    names = list(inspect.signature(updater).parameters)
+    if len(names) == 1:
+        return
+    if len(names) == 2:
+        if names == ["total_update", "item_updates"]:
+            return
+        raise TypeError(f"Function {updater} must have either one argument or "
+                        f"two named arguments (total_update, item_updates)")
+    raise TypeError(f"Function {updater} must take exactly 1 or 2 arguments, "
+                    f"but got {len(names)}")
+
+
 @pytest.fixture
 def fake_xet(monkeypatch):
     """Stand-in hf_xet whose upload functions match the real signature.
@@ -91,6 +115,7 @@ def fake_xet(monkeypatch):
     def upload_files(file_paths, endpoint, token_info, token_refresher,
                      progress_updater, _repo_type, request_headers=None,
                      sha256s=None, skip_sha256=False):
+        _reject_like_hf_xet(progress_updater)
         calls.append(progress_updater)
         return "committed"
 
@@ -108,6 +133,19 @@ def test_the_real_hf_xet_signature_still_has_the_progress_argument():
     index = hf._xet_progress_index(hf_xet.upload_files)
 
     assert index == 4, f"hf_xet.upload_files moved its progress argument to {index}"
+
+
+def test_the_updater_signature_is_one_the_real_hf_xet_accepts():
+    # The signature IS the contract: hf_xet inspects the callback and refuses
+    # anything that is not one parameter or exactly (total_update, item_updates).
+    # A refused callback fails the upload before a byte moves, so every attempt
+    # fails identically — strictly worse than having no heartbeat.
+    pytest.importorskip("hf_xet")
+
+    names = list(inspect.signature(hf._marking_updater(None)).parameters)
+
+    assert names == ["total_update", "item_updates"], \
+        f"hf_xet will reject a progress callback taking {names}"
 
 
 def test_the_injected_updater_marks_the_heartbeat(fake_xet):

--- a/uv.lock
+++ b/uv.lock
@@ -1626,6 +1626,9 @@ urdf = [
     { name = "onshape-to-robot" },
     { name = "pybullet" },
 ]
+vision = [
+    { name = "opencv-python-headless" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1635,6 +1638,7 @@ requires-dist = [
     { name = "depthai", marker = "extra == 'rpi'", specifier = ">=3.6,<4" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "gpiod", marker = "extra == 'rpi'", specifier = ">=2.0.0" },
+    { name = "grabette", extras = ["vision"], marker = "extra == 'rpi'" },
     { name = "gradio", marker = "extra == 'ui'", specifier = ">=5.0.0" },
     { name = "grpcio", marker = "extra == 'teleop-bridge'", specifier = ">=1.60" },
     { name = "httpx", marker = "extra == 'hf'", specifier = ">=0.27" },
@@ -1642,7 +1646,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.20.0" },
     { name = "numpy", marker = "extra == 'teleop-bridge'" },
     { name = "onshape-to-robot", marker = "extra == 'urdf'", specifier = ">=1.8.1" },
-    { name = "opencv-python-headless", marker = "extra == 'rpi'", specifier = ">=4.8" },
+    { name = "opencv-python-headless", marker = "extra == 'vision'", specifier = ">=4.8" },
     { name = "picamera2", marker = "extra == 'rpi'" },
     { name = "protobuf", marker = "extra == 'teleop-bridge'", specifier = ">=4.25" },
     { name = "pybullet", marker = "extra == 'urdf'", specifier = ">=3.2.7" },
@@ -1654,7 +1658,7 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'teleop-bridge'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
-provides-extras = ["rpi", "hf", "urdf", "ui", "teleop-bridge", "test"]
+provides-extras = ["rpi", "vision", "hf", "urdf", "ui", "teleop-bridge", "test"]
 
 [[package]]
 name = "grabette-postprocess"


### PR DESCRIPTION
Fix several errors:
- missing sensors files are detected 
- an empty dataset upload does not look successful
- episode exclusion is mentioned to the user (with the reason why the episodes has been excluded)
- metadata error does not lead to an empty task list on the grabette's dashboard

To be tested with the corresponding branch of grabette-fleet (fix/sensors_errors)