### PR TITLE
Simplify test vs prod

### DIFF
--- a/docs/source/spaces.md
+++ b/docs/source/spaces.md
@@ -47,4 +47,10 @@ Both Spaces run on the free CPU tier.
 
 The `-test` variants of these Spaces are development deployments. Use the ones linked above.
 
+If you do need to work against them, set `GRABETTE_FLEET_ENV=test` on the device
+rather than writing a URL: it moves the relay and the OAuth redirect together, and
+the dashboard then shows an amber fleet tile naming the Space, so no device stays
+pointed there by accident. The fleet Space picks its own conversion Space to
+match, so a test fleet never converts through the production pipeline.
+
 </Tip>

--- a/packages/casquette/casquette/config.py
+++ b/packages/casquette/casquette/config.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import uuid
 from pathlib import Path
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
+
+from casquette.fleet import spaces
 
 
 def _stable_device_id() -> str:
@@ -66,7 +68,10 @@ class Settings(BaseSettings):
     # The device connects OUTBOUND to relay_url, authenticates with its local
     # HF token, and polls for group start/stop commands. Empty token / disabled
     # / unreachable → the device just runs solo (fleet is best-effort).
-    relay_url: str = "https://pollen-robotics-grabette-fleet.hf.space"
+    # Derived from CASQUETTE_FLEET_ENV (see casquette.fleet.spaces): pointing a
+    # device at the test deployment is one named env var, not a URL copied around.
+    # CASQUETTE_RELAY_URL still overrides, as usual for a Settings field.
+    relay_url: str = Field(default_factory=lambda: spaces.space_url("fleet"))
     relay_enabled: bool = True
 
     # Logging

--- a/packages/casquette/casquette/fleet/spaces.py
+++ b/packages/casquette/casquette/fleet/spaces.py
@@ -1,0 +1,66 @@
+# Mirrors grabette/spaces.py for the casquette fleet prototype. Deviations: the
+# env vars carry casquette's CASQUETTE_ prefix (its Settings does), and there is
+# no OAuth relay here — only the relay client consumes this. The Space NAMES are
+# identical on purpose: both device types report to one fleet. Keep in sync until
+# extracted to a shared package. See casquette/fleet/__init__.py.
+"""Which HuggingFace Spaces this device talks to — the one place that knows.
+
+A casquette registers with the SAME fleet Space as a grabette — the fleet is
+per-operator, not per-device-type — so the URLs are built the same way and must
+move together when the deployment changes.
+
+Switching to the development deployment is one line in /etc/casquette/env:
+
+    CASQUETTE_FLEET_ENV=test
+
+No URL to retype. CASQUETTE_RELAY_URL still wins when it is set — that is how a
+duplicated Space is targeted (see grabette's docs/source/spaces.md).
+
+Note "" does NOT stand for "no relay" here: casquette has no OAuth module, so an
+empty URL just leaves the relay client with nothing to call. Standalone is
+CASQUETTE_RELAY_ENABLED=false.
+"""
+
+from __future__ import annotations
+
+import os
+
+PROD = "prod"
+TEST = "test"
+_ORG = "pollen-robotics"
+# Read straight from the environment so this stays usable before any Settings
+# instance exists (grabette's copy needs that for its OAuth module).
+_ENV_VAR = "CASQUETTE_FLEET_ENV"
+
+
+def fleet_env() -> str:
+    """Which deployment this device targets: "prod" (default) or "test".
+
+    Anything unrecognised is prod. A typo must not be the thing that quietly
+    points a device at the development fleet — the failure mode of guessing wrong
+    is a day of recordings landing where nobody looks for them."""
+    return TEST if (os.environ.get(_ENV_VAR) or "").strip().lower() == TEST else PROD
+
+
+def is_test() -> bool:
+    return fleet_env() == TEST
+
+
+def space_name(kind: str) -> str:
+    """e.g. space_name("fleet") -> "grabette-fleet-test" on the test env."""
+    return f"grabette-{kind}" + ("-test" if is_test() else "")
+
+
+def space_url(kind: str) -> str:
+    return f"https://{_ORG}-{space_name(kind)}.hf.space"
+
+
+def fleet_url() -> str:
+    """The fleet Space this device registers with.
+
+    CASQUETTE_RELAY_URL wins when PRESENT, empty included — "" means "no relay",
+    which is a real setting, not a missing one."""
+    override = os.environ.get("CASQUETTE_RELAY_URL")
+    if override is not None:
+        return override.rstrip("/")
+    return space_url("fleet")

--- a/packages/casquette/casquette/fleet/spaces.py
+++ b/packages/casquette/casquette/fleet/spaces.py
@@ -58,9 +58,14 @@ def space_url(kind: str) -> str:
 def fleet_url() -> str:
     """The fleet Space this device registers with.
 
-    CASQUETTE_RELAY_URL wins when PRESENT, empty included — "" means "no relay",
-    which is a real setting, not a missing one."""
+    CASQUETTE_RELAY_URL wins when PRESENT, empty included. "" is not "no relay"
+    here (see the module docstring) — standalone is CASQUETTE_RELAY_ENABLED=false."""
     override = os.environ.get("CASQUETTE_RELAY_URL")
     if override is not None:
         return override.rstrip("/")
     return space_url("fleet")
+
+
+def is_overridden() -> bool:
+    """Is the fleet URL something other than the one this env derives?"""
+    return fleet_url() != space_url("fleet")

--- a/packages/grabette/docs/configuration.md
+++ b/packages/grabette/docs/configuration.md
@@ -32,7 +32,43 @@ All settings via environment variables with `GRABETTE_` prefix. Persistent per-d
 | `GRABETTE_SOUND_ENABLED` | `true` | Cues on the HAT speaker: recording start, recording stop, episode saved, failed command |
 | `GRABETTE_SOUND_DEVICE` | (auto) | ALSA device. Empty = auto-detect the codec by card name (`plughw:CARD=aic3104`) |
 | `GRABETTE_SOUND_VOLUME` | `0.6` | Amplitude of the generated cue, `0`..`1` (absolute loudness is the codec mixer's job) |
+| `GRABETTE_FLEET_ENV` | `prod` | Which fleet deployment to report to: `prod` or `test`. Derives both the relay URL and the OAuth redirect. Anything else reads as `prod` |
+| `GRABETTE_RELAY_URL` | (from `GRABETTE_FLEET_ENV`) | Explicit fleet Space URL — overrides `GRABETTE_FLEET_ENV`. Empty string selects direct OAuth; it does **not** stop the relay client |
+| `GRABETTE_RELAY_ENABLED` | `true` | `false` = fully standalone: no fleet registration, no group sync, no HF token auto-refresh |
 | `GRABETTE_LOG_LEVEL` | `INFO` | Logging level |
+
+### Pointing a device at the test fleet
+
+One line in `/etc/grabette/env`, then restart the service:
+
+```bash
+GRABETTE_FLEET_ENV=test
+```
+
+The dashboard's fleet tile turns amber and names the Space it points at, so a
+device left on the test deployment is visible rather than silently recording
+into a fleet nobody watches. Remove the line to go back to production —
+nothing in the repo ever defaults to `test`.
+
+The fleet Space URL is also the OAuth redirect_uri, so the test Space must be
+registered as one in the HF OAuth app or login fails on a device pointed at it.
+
+### Running a device standalone
+
+```bash
+GRABETTE_RELAY_ENABLED=false
+```
+
+The device never registers with a fleet, never polls for commands, and every
+start/stop stays local — the physical button and the dashboard work exactly as
+usual, solo. It also stops the periodic HF token refresh, which exists to keep
+the relay's token valid.
+
+`GRABETTE_RELAY_URL=""` is *not* the same switch, despite reading like it: it
+puts OAuth in direct mode (redirect_uri points at this device rather than a
+Space), which is what local dev wants, but the relay client still starts and
+retries against an empty URL once per poll interval. Use `GRABETTE_RELAY_ENABLED`
+to actually stop it, and both together for local dev without a Space.
 
 ## Audible recording cue
 

--- a/packages/grabette/grabette/auth.py
+++ b/packages/grabette/grabette/auth.py
@@ -7,9 +7,16 @@ state. The token is persisted with the standard ``huggingface_hub`` mechanism
 Config is read from the environment so the team can point it at their own HF
 OAuth app:
 
-    GRABETTE_RELAY_URL   URL of the grabette-fleet Space acting as OAuth relay.
-                         Defaults to the Pollen fleet Space — no config needed on Pi.
-                         Set to empty string to disable relay (e.g. for local dev).
+    GRABETTE_FLEET_ENV   Which fleet deployment to target: "prod" (default) or
+                         "test". Derives the relay + redirect_uri — see
+                         grabette.spaces. No config needed on a Pi.
+    GRABETTE_RELAY_URL   Explicit URL of the grabette-fleet Space acting as OAuth
+                         relay. Overrides GRABETTE_FLEET_ENV (e.g. a duplicated
+                         Space). Empty string selects DIRECT OAuth — redirect_uri
+                         points at this device instead of a Space (local dev).
+                         It only re-points OAuth: the relay client still starts,
+                         with no URL to call. Running standalone is
+                         GRABETTE_RELAY_ENABLED=false.
     GRABETTE_BASE_URL    Direct public URL of this grabette (overrides auto-detect).
                          Only needed when not using the relay (e.g. local dev).
                          (default without relay: http://localhost:8000)
@@ -40,6 +47,8 @@ import aiohttp
 from huggingface_hub import get_token, logout, whoami
 from huggingface_hub.errors import HfHubHTTPError
 
+from grabette import spaces
+
 # --- configuration ----------------------------------------------------------
 # The hostname is encoded into the OAuth state when using the relay, so the
 # relay knows which grabette to forward the callback to.
@@ -59,8 +68,10 @@ def _write_secret(path: Path, text: str) -> None:
 
 _HOSTNAME = socket.gethostname()
 
-_DEFAULT_RELAY_URL = "https://pollen-robotics-grabette-fleet.hf.space"
-_RELAY_URL = os.environ.get("GRABETTE_RELAY_URL", _DEFAULT_RELAY_URL).rstrip("/")
+# Same answer as Settings.relay_url, from the same place — the redirect_uri and
+# the relay the device polls MUST be the same Space, or login bounces on a device
+# that otherwise registers fine.
+_RELAY_URL = spaces.fleet_url()
 OAUTH_CALLBACK_PATH = "/api/hf-auth/oauth/callback"
 
 if _RELAY_URL:

--- a/packages/grabette/grabette/config.py
+++ b/packages/grabette/grabette/config.py
@@ -6,8 +6,10 @@ import uuid
 from pathlib import Path
 from typing import Literal
 
-from pydantic import field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
+
+from grabette import spaces
 
 
 def _stable_device_id() -> str:
@@ -96,8 +98,11 @@ class Settings(BaseSettings):
     # Logging
     log_level: str = "INFO"
 
-    # Fleet relay
-    relay_url: str = "https://pollen-robotics-grabette-fleet.hf.space"
+    # Fleet relay. Derived from GRABETTE_FLEET_ENV (see grabette.spaces) so
+    # pointing a device at the test deployment is one named env var and not a
+    # URL copied into two files. GRABETTE_RELAY_URL still overrides, as usual
+    # for a Settings field.
+    relay_url: str = Field(default_factory=lambda: spaces.space_url("fleet"))
     relay_enabled: bool = True
     device_id: str = ""
     device_name: str = ""

--- a/packages/grabette/grabette/spaces.py
+++ b/packages/grabette/grabette/spaces.py
@@ -61,9 +61,19 @@ def space_url(kind: str) -> str:
 def fleet_url() -> str:
     """The fleet Space this device registers with and logs in through.
 
-    GRABETTE_RELAY_URL wins when PRESENT, empty included — "" means "no relay",
-    which is a real setting, not a missing one."""
+    GRABETTE_RELAY_URL wins when PRESENT, empty included — "" is a real setting
+    (direct OAuth, see the module docstring), not a missing one. It does not stop
+    the relay client; GRABETTE_RELAY_ENABLED=false does."""
     override = os.environ.get("GRABETTE_RELAY_URL")
     if override is not None:
         return override.rstrip("/")
     return space_url("fleet")
+
+
+def is_overridden() -> bool:
+    """Is the fleet URL something other than the one this env derives?
+
+    Asked so the dashboard can flag ANY unusual target, not just the test
+    deployment: a device pointed at a personal Space is just as easy to forget,
+    and used to look exactly like production."""
+    return fleet_url() != space_url("fleet")

--- a/packages/grabette/grabette/spaces.py
+++ b/packages/grabette/grabette/spaces.py
@@ -1,0 +1,69 @@
+"""Which HuggingFace Spaces this device talks to — the one place that knows.
+
+The fleet Space URL used to be a literal in three independent spots (this
+package's Settings default, auth.py's OAuth relay, and casquette's mirror of the
+same setting). Renaming or re-pointing a Space meant finding all three, and the
+one that got missed failed in a confusing way: a device that registers with the
+fleet fine but whose login bounces, because auth.py built its redirect_uri from
+a different Space than the relay client polls.
+
+Switching to the development deployment is one line in /etc/grabette/env:
+
+    GRABETTE_FLEET_ENV=test
+
+No URL to retype, and both the relay and the OAuth redirect move together.
+GRABETTE_RELAY_URL still wins when it is set — that is how a duplicated Space is
+targeted (see docs/source/spaces.md), and "" selects direct OAuth for local dev.
+
+"" re-points OAuth and nothing else: the relay client still starts, with no URL
+to call. A device meant to run standalone wants GRABETTE_RELAY_ENABLED=false,
+which stops the relay client, the HF token refresh and group sync together.
+
+One thing this cannot do for you: the fleet Space URL is also the OAuth
+redirect_uri, so the test Space must be registered as one in the HF OAuth app or
+login fails on a device pointed at it.
+"""
+
+from __future__ import annotations
+
+import os
+
+PROD = "prod"
+TEST = "test"
+_ORG = "pollen-robotics"
+# The env var is read here rather than through Settings because auth.py needs the
+# answer at import time, before any Settings instance exists.
+_ENV_VAR = "GRABETTE_FLEET_ENV"
+
+
+def fleet_env() -> str:
+    """Which deployment this device targets: "prod" (default) or "test".
+
+    Anything unrecognised is prod. A typo must not be the thing that quietly
+    points a device at the development fleet — the failure mode of guessing wrong
+    is a day of recordings landing where nobody looks for them."""
+    return TEST if (os.environ.get(_ENV_VAR) or "").strip().lower() == TEST else PROD
+
+
+def is_test() -> bool:
+    return fleet_env() == TEST
+
+
+def space_name(kind: str) -> str:
+    """e.g. space_name("fleet") -> "grabette-fleet-test" on the test env."""
+    return f"grabette-{kind}" + ("-test" if is_test() else "")
+
+
+def space_url(kind: str) -> str:
+    return f"https://{_ORG}-{space_name(kind)}.hf.space"
+
+
+def fleet_url() -> str:
+    """The fleet Space this device registers with and logs in through.
+
+    GRABETTE_RELAY_URL wins when PRESENT, empty included — "" means "no relay",
+    which is a real setting, not a missing one."""
+    override = os.environ.get("GRABETTE_RELAY_URL")
+    if override is not None:
+        return override.rstrip("/")
+    return space_url("fleet")

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -10,6 +10,7 @@ import math
 import gradio as gr
 from PIL import Image
 
+from grabette import spaces
 from grabette.config import settings
 from grabette.ui.api_client import GrabetteClient
 
@@ -876,15 +877,25 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
         # here — it's OAuth-gated and this dashboard is served over plain HTTP,
         # so its login can't render in an iframe — so we link out in a new tab,
         # where the HF session and OAuth work normally.
+        # WHICH fleet, not just "the" fleet: a device left on the test deployment
+        # keeps working perfectly and records into a fleet nobody is watching, and
+        # nothing on this page used to say so. The Space name is always shown, and
+        # the tile turns amber on anything that isn't prod — see grabette.spaces.
+        _test = spaces.is_test()
+        _target = settings.relay_url.replace("https://", "")
+        _grad = ("linear-gradient(135deg,#d97706,#b45309)" if _test
+                 else "linear-gradient(135deg,#10b981,#3b82f6)")
         gr.HTML(
             f'<a href="{settings.relay_url}" target="_blank" rel="noopener" '
             'style="display:block;margin-top:1.2rem;padding:2.6rem 1.5rem;border-radius:16px;'
             'text-align:center;text-decoration:none;color:#fff;'
-            'background:linear-gradient(135deg,#10b981,#3b82f6);'
+            f'background:{_grad};'
             'box-shadow:0 6px 22px rgba(0,0,0,.28);">'
-            '<div style="font-size:1.7rem;font-weight:800;">Open fleet dashboard ↗</div>'
+            + ('<div style="font-size:.8rem;font-weight:800;letter-spacing:.08em;'
+               'margin-bottom:.5rem;">⚠ TEST DEPLOYMENT</div>' if _test else '')
+            + '<div style="font-size:1.7rem;font-weight:800;">Open fleet dashboard ↗</div>'
             '<div style="font-size:.95rem;opacity:.85;margin-top:.5rem;font-weight:500;">'
-            'Manage tasks, sessions and datasets on grabette-fleet</div></a>'
+            f'Manage tasks, sessions and datasets on {_target}</div></a>'
         )
         batt_popup_cn = gr.HTML(visible=False)
         batt_beep_cn = gr.Textbox(visible=False)

--- a/packages/grabette/grabette/ui/app.py
+++ b/packages/grabette/grabette/ui/app.py
@@ -880,10 +880,14 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
         # WHICH fleet, not just "the" fleet: a device left on the test deployment
         # keeps working perfectly and records into a fleet nobody is watching, and
         # nothing on this page used to say so. The Space name is always shown, and
-        # the tile turns amber on anything that isn't prod — see grabette.spaces.
+        # the tile turns amber on anything that is not the derived production
+        # Space — an explicit GRABETTE_RELAY_URL included, which is just as easy
+        # to forget as the test env and used to look exactly like production.
         _test = spaces.is_test()
-        _target = settings.relay_url.replace("https://", "")
-        _grad = ("linear-gradient(135deg,#d97706,#b45309)" if _test
+        _custom = spaces.is_overridden()
+        _flag = "⚠ TEST DEPLOYMENT" if _test else "⚠ CUSTOM FLEET" if _custom else ""
+        _target = settings.relay_url.replace("https://", "") or "no fleet (relay URL unset)"
+        _grad = ("linear-gradient(135deg,#d97706,#b45309)" if (_test or _custom)
                  else "linear-gradient(135deg,#10b981,#3b82f6)")
         gr.HTML(
             f'<a href="{settings.relay_url}" target="_blank" rel="noopener" '
@@ -891,8 +895,8 @@ def create_ui(api_url: str | None = None) -> gr.Blocks:
             'text-align:center;text-decoration:none;color:#fff;'
             f'background:{_grad};'
             'box-shadow:0 6px 22px rgba(0,0,0,.28);">'
-            + ('<div style="font-size:.8rem;font-weight:800;letter-spacing:.08em;'
-               'margin-bottom:.5rem;">⚠ TEST DEPLOYMENT</div>' if _test else '')
+            + (f'<div style="font-size:.8rem;font-weight:800;letter-spacing:.08em;'
+               f'margin-bottom:.5rem;">{_flag}</div>' if _flag else '')
             + '<div style="font-size:1.7rem;font-weight:800;">Open fleet dashboard ↗</div>'
             '<div style="font-size:.95rem;opacity:.85;margin-top:.5rem;font-weight:500;">'
             f'Manage tasks, sessions and datasets on {_target}</div></a>'

--- a/packages/grabette/tests/test_spaces.py
+++ b/packages/grabette/tests/test_spaces.py
@@ -1,0 +1,104 @@
+"""Which fleet Space a device targets, and what it takes to move it.
+
+The URL used to be a literal in three places, and the interesting failure was
+never "wrong URL" — it was two of the three disagreeing: a device that registers
+with one fleet while building its OAuth redirect_uri from another, which logs in
+nowhere. So the pair is asserted together here, not just the value.
+
+The other half is that prod must be what you get by DEFAULT and by accident: an
+unset variable, a typo, a stray case. Only the exact word "test" moves a device
+off production.
+"""
+from __future__ import annotations
+
+import pytest
+
+from grabette import spaces
+
+PROD_FLEET = "https://pollen-robotics-grabette-fleet.hf.space"
+TEST_FLEET = "https://pollen-robotics-grabette-fleet-test.hf.space"
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    monkeypatch.delenv("GRABETTE_FLEET_ENV", raising=False)
+    monkeypatch.delenv("GRABETTE_RELAY_URL", raising=False)
+    yield
+
+
+def test_the_default_is_production():
+    assert spaces.fleet_env() == spaces.PROD
+    assert spaces.fleet_url() == PROD_FLEET
+
+
+def test_one_named_var_moves_the_device_to_test(monkeypatch):
+    monkeypatch.setenv("GRABETTE_FLEET_ENV", "test")
+    assert spaces.is_test()
+    assert spaces.fleet_url() == TEST_FLEET
+
+
+@pytest.mark.parametrize("value", ["TEST", " test ", "Test"])
+def test_the_test_value_is_case_and_space_insensitive(monkeypatch, value):
+    monkeypatch.setenv("GRABETTE_FLEET_ENV", value)
+    assert spaces.fleet_url() == TEST_FLEET
+
+
+@pytest.mark.parametrize("value", ["", "prod", "tset", "testing", "dev", "1", "true"])
+def test_anything_that_is_not_test_is_production(monkeypatch, value):
+    # A typo must not be what points a device at the development fleet — a day of
+    # recordings would land where nobody looks for them, and the device would
+    # give no sign of it.
+    monkeypatch.setenv("GRABETTE_FLEET_ENV", value)
+    assert spaces.fleet_url() == PROD_FLEET
+
+
+def test_an_explicit_url_wins_over_the_env(monkeypatch):
+    # How a duplicated Space is targeted (docs/source/spaces.md).
+    monkeypatch.setenv("GRABETTE_FLEET_ENV", "test")
+    monkeypatch.setenv("GRABETTE_RELAY_URL", "https://me-grabette-fleet.hf.space/")
+    assert spaces.fleet_url() == "https://me-grabette-fleet.hf.space"
+
+
+def test_an_empty_url_is_honoured_rather_than_falling_back_to_a_default(monkeypatch):
+    # "" is a real setting (direct OAuth for local dev), not a missing one, so it
+    # must NOT fall through to the derived Space URL. It does not by itself stop
+    # the relay client — that is GRABETTE_RELAY_ENABLED, a different setting.
+    monkeypatch.setenv("GRABETTE_RELAY_URL", "")
+    assert spaces.fleet_url() == ""
+
+
+def test_both_consumers_read_the_same_source():
+    """THE bug the three duplicated literals invited: the relay the device polls
+    and the Space its redirect_uri points at drifting apart, so a device
+    registers with one fleet and logs in nowhere.
+
+    Asserted by showing both derive from spaces.fleet_url() under the ambient
+    environment — NOT by reloading the two modules under a patched env. auth.py
+    resolves its URLs at import time, so a reload rebinds config.settings for
+    every later test in the session, which is how this file used to break
+    test_task.py. Since the other tests here pin how fleet_url() moves, one
+    shared source is enough to prove the pair moves together."""
+    from grabette import auth
+    from grabette.config import Settings
+
+    assert Settings().relay_url == spaces.fleet_url()
+    assert auth.OAUTH_REDIRECT_URI == spaces.fleet_url() + "/oauth/grabette/callback"
+
+
+def test_the_relay_default_is_computed_not_frozen(monkeypatch):
+    """The field must keep a default_factory: a literal default would be baked in
+    at class-creation time and GRABETTE_FLEET_ENV would silently stop working."""
+    from grabette.config import Settings
+
+    factory = Settings.model_fields["relay_url"].default_factory
+    assert factory is not None
+    monkeypatch.setenv("GRABETTE_FLEET_ENV", "test")
+    assert factory() == TEST_FLEET
+
+
+def test_no_shipped_default_points_at_a_test_space(monkeypatch):
+    # The guarantee for main: with nothing set anywhere, no committed default can
+    # reach a "-test" Space.
+    assert "-test" not in spaces.fleet_url()
+    assert "-test" not in spaces.space_url("fleet")
+    assert "-test" not in spaces.space_url("slam")

--- a/packages/grabette/tests/test_spaces.py
+++ b/packages/grabette/tests/test_spaces.py
@@ -102,3 +102,33 @@ def test_no_shipped_default_points_at_a_test_space(monkeypatch):
     assert "-test" not in spaces.fleet_url()
     assert "-test" not in spaces.space_url("fleet")
     assert "-test" not in spaces.space_url("slam")
+
+
+def test_the_derived_url_is_not_an_override():
+    assert not spaces.is_overridden()
+
+
+def test_the_derived_test_url_is_not_an_override(monkeypatch):
+    monkeypatch.setenv("GRABETTE_FLEET_ENV", "test")
+    assert not spaces.is_overridden()
+
+
+def test_a_third_space_is_an_override_on_either_env(monkeypatch):
+    # The case the dashboard used to paint exactly like production.
+    monkeypatch.setenv("GRABETTE_RELAY_URL", "https://gaelle-grabette-fleet.hf.space")
+    assert spaces.is_overridden()
+    monkeypatch.setenv("GRABETTE_FLEET_ENV", "test")
+    assert spaces.is_overridden()
+
+
+def test_writing_the_default_out_by_hand_is_not_an_override(monkeypatch):
+    # No false alarm, or the flag stops meaning anything. Trailing slash included.
+    monkeypatch.setenv("GRABETTE_RELAY_URL", PROD_FLEET + "/")
+    assert not spaces.is_overridden()
+
+
+def test_an_empty_relay_url_counts_as_an_override(monkeypatch):
+    # It is not the derived Space, and the tile says "no fleet" rather than
+    # showing a green production tile with a blank target.
+    monkeypatch.setenv("GRABETTE_RELAY_URL", "")
+    assert spaces.is_overridden()


### PR DESCRIPTION
Add `GRABETTE_FLEET_ENV=test` to `/etc/grabette/env` to use a grabette with the test space instead of the production one. Can also use a custom space with `GRABETTE_RELAY_URL`
The state of the grabette is visible to know easily which space is targeted

<img width="1052" height="379" alt="image" src="https://github.com/user-attachments/assets/8f7967ef-a848-4f77-a239-8f1bb7ebadcf" />
